### PR TITLE
Mpi dispatcher using mpi4py. (Nick Lubbers contributor)

### DIFF
--- a/docs/PARALLEL.md
+++ b/docs/PARALLEL.md
@@ -12,15 +12,15 @@ There are two mechanisms for parallelization: Multiprocessing and MPI.
 The former is simpler, but limited to one node.
 However, if only using one node, Multiprocessing will be slightly faster than MPI.
 
-Because steps 1 and 3 are still in serial, there are limits on how useful parallelization can be.
-It will be most helpful for larger datasets with large numbers of bispectrum components (large `twojmax`).
+Scaling step 2 over more and more cores will eventually (10-20 cores) cause the total running time to be dominated by the serial steps 1 and 3 (Amdahl's Law).
+Running step 2 in parallel is most helpful for larger datasets with large numbers of bispectrum components (large `twojmax`).
 There are also communication overheads associated with parallelization, as the simple map strategy used
 involves all-to-one type communication patterns.
 
 ## Multiprocessing Parallelization
 
 - `Multiprocessing` comes as part of the python standard library; no installation needed.
-- Use the `-j <N>` or `--jobs <N>` argument to set a number of processes.
+- Use the `-j <N>` or `--jobs <N>` argument to set the number of processes.
 Python's Multiprocessing module will be used to start that many process, and in each one an instance of LAMMPS.
 - This form of Parallelization can thus only be used on a single node.
 - It will most likely not help to set the number of jobs any larger than the number of cores available.
@@ -28,20 +28,21 @@ Python's Multiprocessing module will be used to start that many process, and in 
 ## MPI Parallelization
 
 - Install `mpi4py`, version 3.0.0 or greater. (Tested with 3.0.1)
-- Tested with `mpich/3.1.3 gcc_4.8.5` and `intel-mpi intel` mpi & compilier setups.
+- Tested with `mpich/3.1.3 gcc_4.8.5` and `intel-mpi intel` mpi & compiler setups.
 - Launch FitSnap3 with mpiexec using **1** initial process.
-- Send FitSnap3 the flag `--mpi` **in addition to** `-j <N>` for N ranks.
-- FitSnap3 will use mpi4py's MPIPoolExecutor class to spawn N new processes across the allocation,
+- Send FitSnap3 the flag `--mpi` **in addition to** `-j <N>`, where `<N>` is the total number of processes.
+- FitSnap3 will use mpi4py's MPIPoolExecutor class to spawn N new processes across the allocated nodes,
 and farm out the LAMMPS calculation to these processes. 
-- Example call: `mpiexec -n 1 python -m fitsnap3 examples/WBe_PRB2019/WBe-example.in -j 512 --mpi`
-- Note that if you are working on one node, there is no known advantage to using MPI over multiprocessing.
+- Example call: Assuming the job has been allocated 32 nodes with 16 cores per node
 
+      `mpiexec -n 1 python -m fitsnap3 examples/WBe_PRB2019/WBe-example.in -j 512 --mpi`
+- Note that if you are working on one node, MPI and Multiprocessing should give identical performance.
 
 ## Other aspects of Parallelization:
 
 ### Chunk sizes
 
-`fitnsap3/deploy.py` constains a global variable `DEFAULT_CHUNKSIZE` that controls the number
+`fitnsap3/deploy.py` contains a global variable `DEFAULT_CHUNKSIZE` that controls the number
 of configurations which each process will consume before communicating results back to the main process.
 If you find yourself wanting to tune your parallelization for best performance, this variable can play a role.
 At lower chunk sizes, communication will be more frequent and expensive,
@@ -49,15 +50,13 @@ but possibly allowing for better load-balancing between processes.
 At higher chunk sizes, communication will be less frequent and more efficient,
 but load distribution between processes might suffer.
 
-We don't expect the variable to play a huge role in practical situations, however,
-if you do find that tuning the chunksize plays a significant role in the fit 
-
- 
+For typical fits running on typical hardware, the default value of DEFAULT_CHUNKSIZE=10
+yields close to 100% efficiency, and there is no need to change it. 
 
 ### LAMMPS Parallelization
 
 FitSnap3's parallelization mechanisms work orthogonally to any parallelization in LAMMPS,
-e.g. OMP thread parallelization.If you do not use any parallelization in LAMMPS,
-you should probably set the number of processes to parallelize to the number of cores/ranks available.
+e.g. OpenMP thread parallelization. If you do not use any parallelization in LAMMPS,
+you should probably set the number of FitSNAP processes `<N>` to the number of cores/ranks available.
  
 

--- a/docs/PARALLEL.md
+++ b/docs/PARALLEL.md
@@ -1,0 +1,63 @@
+# Parallel Features
+
+FitSnap3 consists of three main phases:
+
+1) Scraping the data from JSON Files and reading configuration files.
+2) Using LAMMPS to compute bispectrum coefficients for SNAP.
+3) Solving for SNAP coefficients.
+
+Currently, only step 2 is set up for parallel calculation.
+
+There are two mechanisms for parallelization: Multiprocessing and MPI.
+The former is simpler, but limited to one node.
+However, if only using one node, Multiprocessing will be slightly faster than MPI.
+
+Because steps 1 and 3 are still in serial, there are limits on how useful parallelization can be.
+It will be most helpful for larger datasets with large numbers of bispectrum components (large `twojmax`).
+There are also communication overheads associated with parallelization, as the simple map strategy used
+involves all-to-one type communication patterns.
+
+## Multiprocessing Parallelization
+
+- `Multiprocessing` comes as part of the python standard library; no installation needed.
+- Use the `-j <N>` or `--jobs <N>` argument to set a number of processes.
+Python's Multiprocessing module will be used to start that many process, and in each one an instance of LAMMPS.
+- This form of Parallelization can thus only be used on a single node.
+- It will most likely not help to set the number of jobs any larger than the number of cores available.
+
+## MPI Parallelization
+
+- Install `mpi4py`, version 3.0.0 or greater. (Tested with 3.0.1)
+- Tested with `mpich/3.1.3 gcc_4.8.5` and `intel-mpi intel` mpi & compilier setups.
+- Launch FitSnap3 with mpiexec using **1** initial process.
+- Send FitSnap3 the flag `--mpi` **in addition to** `-j <N>` for N ranks.
+- FitSnap3 will use mpi4py's MPIPoolExecutor class to spawn N new processes across the allocation,
+and farm out the LAMMPS calculation to these processes. 
+- Example call: `mpiexec -n 1 python -m fitsnap3 examples/WBe_PRB2019/WBe-example.in -j 512 --mpi`
+- Note that if you are working on one node, there is no known advantage to using MPI over multiprocessing.
+
+
+## Other aspects of Parallelization:
+
+### Chunk sizes
+
+`fitnsap3/deploy.py` constains a global variable `DEFAULT_CHUNKSIZE` that controls the number
+of configurations which each process will consume before communicating results back to the main process.
+If you find yourself wanting to tune your parallelization for best performance, this variable can play a role.
+At lower chunk sizes, communication will be more frequent and expensive,
+but possibly allowing for better load-balancing between processes.
+At higher chunk sizes, communication will be less frequent and more efficient,
+but load distribution between processes might suffer.
+
+We don't expect the variable to play a huge role in practical situations, however,
+if you do find that tuning the chunksize plays a significant role in the fit 
+
+ 
+
+### LAMMPS Parallelization
+
+FitSnap3's parallelization mechanisms work orthogonally to any parallelization in LAMMPS,
+e.g. OMP thread parallelization.If you do not use any parallelization in LAMMPS,
+you should probably set the number of processes to parallelize to the number of cores/ranks available.
+ 
+

--- a/fitsnap3/__init__.py
+++ b/fitsnap3/__init__.py
@@ -73,6 +73,12 @@ try:
 except Exception as e:
     print("Trouble importing natsort package, exiting...")
     raise e
+#try:
+#    import lammps
+#    print("LAMMPS version: ",lammps.version())
+#except Exception as e:
+#    print("Trouble importing LAMMPS library, exiting...")
+#    raise e
 print("-----------")
 
 from . import bispecopt, deploy, geometry, linearfit, runlammps, scrape, serialize

--- a/fitsnap3/deploy.py
+++ b/fitsnap3/deploy.py
@@ -1,32 +1,33 @@
 # <!----------------BEGIN-HEADER------------------------------------>
-# ## FitSNAP3 
+# ## FitSNAP3
 # A Python Package For Training SNAP Interatomic Potentials for use in the LAMMPS molecular dynamics package
-# 
+#
 # _Copyright (2016) Sandia Corporation. Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains certain rights in this software. This software is distributed under the GNU General Public License_
 # ##
-# 
-# #### Original author: 
+#
+# #### Original author:
 #     Aidan P. Thompson, athomps (at) sandia (dot) gov (Sandia National Labs)
-#     http://www.cs.sandia.gov/~athomps 
-# 
+#     http://www.cs.sandia.gov/~athomps
+#
 # #### Key contributors (alphabetical):
 #     Mary Alice Cusentino (Sandia National Labs)
 #     Nicholas Lubbers (Los Alamos National Lab)
 #     Adam Stephens (Sandia National Labs)
 #     Mitchell Wood (Sandia National Labs)
-# 
-# #### Additional authors (alphabetical): 
+#
+# #### Additional authors (alphabetical):
 #     Elizabeth Decolvenaere (D. E. Shaw Research)
 #     Stan Moore (Sandia National Labs)
 #     Steve Plimpton (Sandia National Labs)
 #     Gary Saavedra (Sandia National Labs)
 #     Peter Schultz (Sandia National Labs)
 #     Laura Swiler (Sandia National Labs)
-#     
+#
 # <!-----------------END-HEADER------------------------------------->
 
 import os
 import copy
+import traceback
 
 import multiprocessing
 
@@ -39,7 +40,7 @@ except ImportError:
 
 from . import runlammps
 
-DEFAULT_CHUNKSIZE = 10
+DEFAULT_CHUNKSIZE = 5
 DEFAULT_LAMMPS_LOG = False
 
 def check_lammps(lammps_noexceptions):
@@ -48,14 +49,17 @@ def check_lammps(lammps_noexceptions):
         raise Exception("Fitting interrupted! LAMMPS not compiled with C++ exceptions handling enabled")
     del lmp
 
-def compute_bispec_datasets(input_configs, bispec_options, n_procs, chunk_size=DEFAULT_CHUNKSIZE,  log=DEFAULT_LAMMPS_LOG):
+def compute_bispec_datasets(input_configs, bispec_options, n_procs, mpi=False,chunk_size=DEFAULT_CHUNKSIZE, log=DEFAULT_LAMMPS_LOG):
     if n_procs == 1:
         results = compute_single(input_configs, bispec_options, log=log)
     else:
-        results = compute_multi(input_configs, bispec_options, n_procs, chunk_size, log=log)
+        if mpi:
+            compute_function = compute_mpi
+        else:
+            compute_function = compute_multi
+        results = compute_function(input_configs, bispec_options, n_procs, chunk_size, log=log)
     assert all(i==j==data["Index"] for i,(j,data) in enumerate(results)),\
         "Configurations dropped or out of order"
-
     return results
 
 ### Compute using single process
@@ -75,9 +79,14 @@ def compute_single(data_dict, bispec_options, log=DEFAULT_LAMMPS_LOG):
         all_data.append((i,data))
     return all_data
 
-### Compute using multiple process and multiprocessing module
+# Parallel Methods
 
+lmpGLOBAL = None
 lmplogGLOBAL = False
+chunkGLOBAL = None
+bispecGLOBAL = None
+
+# For initializing the LAMMPS instance in a new process (MPI or Multiprocessing)
 def initializer():
     global lmpGLOBAL
     #print("Initializing LAMMPS in process", os.getpid())
@@ -87,8 +96,9 @@ def initializer():
     else:
         lmpGLOBAL = lammps.lammps(cmdargs=["-screen","none","-log","none"])
 
-chunkGLOBAL = None
-bispecGLOBAL = None
+
+# Worker function for Multiprocessing
+
 def compute_partial(inputs):
     i, data = inputs
     data = copy.deepcopy(data)
@@ -98,6 +108,8 @@ def compute_partial(inputs):
                                     )
     data.update(comp)
     return (i, data)
+
+#Dispatch function for Multiprocessing
 
 def compute_multi(data_dict, bispec_options, n_procs, chunk_size=DEFAULT_CHUNKSIZE,log=DEFAULT_LAMMPS_LOG):
     global chunkGLOBAL, bispecGLOBAL, lmplogGLOBAL
@@ -109,6 +121,43 @@ def compute_multi(data_dict, bispec_options, n_procs, chunk_size=DEFAULT_CHUNKSI
     with fork.Pool(n_procs, initializer=initializer) as pool:
             results = pool.imap_unordered(compute_partial, enumerate(data_dict), chunksize=chunk_size)#,total=len(data_dict))
             results = list(tqdm.tqdm(results,desc="Configs",total=len(data_dict),disable=(not bispec_options["verbosity"]), ascii=True))
+
+    results = list(sorted(results,key=lambda pair:pair[0]))
+
+    return results
+
+### Worker function using MPI (slight difference because MPI pool doesn't allow an initializer)
+
+def compute_partial_mpi(inputs,bispec=None):
+    try:
+        if lmpGLOBAL is None:
+            initializer()
+        i, data = inputs
+        data = copy.deepcopy(data)
+        comp = runlammps.compute_lammps(lmp=lmpGLOBAL,
+                                        data=data,
+                                        bispec_options=bispec)
+        data.update(comp)
+        return (i, data)
+    except Exception as ee:
+        import sys
+        print("Exception caught from subprocess:")
+        traceback.print_exc()
+        raise RuntimeError("Uncaught exception:\n{}".format(ee)) from ee
+
+### Pool function function using MPI
+
+def compute_mpi(data_dict, bispec_options, n_procs=None, chunk_size=DEFAULT_CHUNKSIZE,log=DEFAULT_LAMMPS_LOG):
+    import mpi4py
+    import mpi4py.futures
+    global bispecGLOBAL, lmplogGLOBAL
+
+    lmplogGLOBAL = log
+    import functools
+    compute = functools.partial(compute_partial_mpi,bispec=bispec_options)
+    with mpi4py.futures.MPIPoolExecutor(max_workers=n_procs) as pool:
+            results = pool.map(compute, enumerate(data_dict), chunksize=chunk_size)#,total=len(data_dict))
+            results = list(tqdm.tqdm(results,desc="Configs",total=len(data_dict),disable=(not bispec_options["verbosity"]),ascii=True))
 
     results = list(sorted(results,key=lambda pair:pair[0]))
 


### PR DESCRIPTION
Using either mpich or intel-mpi communication libraries, openmpi still in testing. Will require mpi4py 3.X or higher, conda or pip will handle this. LAMMPS will need to be re-compiled against these libraries as well. --mpi is now an optional command line switch that will allow --jobs # to exceed the cores on a single node. Coefficients and timings of example cases have been reproduced. Future improvements to a mpi-based training parser and linear solver will be needed to follow onto this PR. 