### PR TITLE
Unit Conversions from Training to LAMMPS styles

### DIFF
--- a/fitsnap3/__main__.py
+++ b/fitsnap3/__main__.py
@@ -231,6 +231,11 @@ def main():
             with printdoing("Measuring errors"):
                 error_metrics = linearfit.group_errors(fit_coeffs,configs,bispec_options,subsystems=subsystems)
                 configs.update(linearfit.get_residuals(fit_coeffs,configs,subsystems=subsystems))
+            print("Units for reported errors:")
+            if bispec_options["units"]=="real":
+                print("Energy(kcal/mol), Force(kcal/mol-Angstrom), Pressure(atm)")
+            if bispec_options["units"]=="metal":
+                print("Energy(eV/atom), Force(eV/Angstrom), Pressure(bar)")
 
             if args.verbose:
                 print_error_summary(error_metrics)

--- a/fitsnap3/geometry.py
+++ b/fitsnap3/geometry.py
@@ -27,10 +27,15 @@
 
 import numpy as np
 
-def unit_conv(styles,bispec_options):
-    units_conv = [1.0]*4
+def units_conv(styles,bispec_options):
+    units_conv = {}
+    units_conv["Energy"] = 1.0
+    units_conv["Force"] = 1.0
+    units_conv["Stress"] = 1.0
+    units_conv["Distance"] = 1.0
+    
     if (bispec_options["units"]=="metal" and (list(styles["Stress"])[0]=="kbar" or list(styles["Stress"])[0]=="kB")):
-        units_conv[2] *= 1000
+        units_conv["Stress"] = 1000.0
 #   Append other exceptions to unit conversion here
 #        if bispec_options["verbosity"]:
 #            print("Energy, Force, Stress, Distance")
@@ -74,9 +79,9 @@ def rotate_coords(data,units_conv):
     # Stress transforms on both the first and second axis.
     return {
         "Lattice": out_cell,
-        "Positions": data["Positions"]*units_conv[3] @ rot.T,
-        "Forces": data["Forces"]*units_conv[1] @ rot.T,
-        "Stress": rot @ (data["Stress"]*units_conv[2]) @ rot.T,
+        "Positions": data["Positions"]*units_conv["Distance"] @ rot.T,
+        "Forces": data["Forces"]*units_conv["Force"] @ rot.T,
+        "Stress": rot @ (data["Stress"]*units_conv["Stress"]) @ rot.T,
         "Rotation": rot,
     }
 

--- a/fitsnap3/geometry.py
+++ b/fitsnap3/geometry.py
@@ -1,34 +1,44 @@
 # <!----------------BEGIN-HEADER------------------------------------>
-# ## FitSNAP3 
+# ## FitSNAP3
 # A Python Package For Training SNAP Interatomic Potentials for use in the LAMMPS molecular dynamics package
-# 
+#
 # _Copyright (2016) Sandia Corporation. Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains certain rights in this software. This software is distributed under the GNU General Public License_
 # ##
-# 
-# #### Original author: 
+#
+# #### Original author:
 #     Aidan P. Thompson, athomps (at) sandia (dot) gov (Sandia National Labs)
-#     http://www.cs.sandia.gov/~athomps 
-# 
+#     http://www.cs.sandia.gov/~athomps
+#
 # #### Key contributors (alphabetical):
 #     Mary Alice Cusentino (Sandia National Labs)
 #     Nicholas Lubbers (Los Alamos National Lab)
 #     Adam Stephens (Sandia National Labs)
 #     Mitchell Wood (Sandia National Labs)
-# 
-# #### Additional authors (alphabetical): 
+#
+# #### Additional authors (alphabetical):
 #     Elizabeth Decolvenaere (D. E. Shaw Research)
 #     Stan Moore (Sandia National Labs)
 #     Steve Plimpton (Sandia National Labs)
 #     Gary Saavedra (Sandia National Labs)
 #     Peter Schultz (Sandia National Labs)
 #     Laura Swiler (Sandia National Labs)
-#     
+#
 # <!-----------------END-HEADER------------------------------------->
 
 import numpy as np
 
+def unit_conv(styles,bispec_options):
+    units_conv = [1.0]*4
+    if (bispec_options["units"]=="metal" and (list(styles["Stress"])[0]=="kbar" or list(styles["Stress"])[0]=="kB")):
+        units_conv[2] *= 1000
+#   Append other exceptions to unit conversion here
+#        if bispec_options["verbosity"]:
+#            print("Energy, Force, Stress, Distance")
+#            print("From JSON: ")
+#            print(list(styles["Energy"])[0],", ", list(styles["Forces"])[0],", ", list(styles["Stress"])[0],", ", list(styles["Positions"])[0])
+    return units_conv
 
-def rotate_coords(data):
+def rotate_coords(data,units_conv):
     # Transpose here because Lammps stores lattice vectors as columns,
     # QM stores lattice vectors as rows; After transposing lattice vectors are columns
     in_cell = np.asarray(data["QMLattice"]).T
@@ -64,14 +74,14 @@ def rotate_coords(data):
     # Stress transforms on both the first and second axis.
     return {
         "Lattice": out_cell,
-        "Positions": data["Positions"] @ rot.T,
-        "Forces": data["Forces"] @ rot.T,
-        "Stress": rot @ data["Stress"] @ rot.T,
+        "Positions": data["Positions"]*units_conv[3] @ rot.T,
+        "Forces": data["Forces"]*units_conv[1] @ rot.T,
+        "Stress": rot @ (data["Stress"]*units_conv[2]) @ rot.T,
         "Rotation": rot,
     }
 
 
-def translate_coords(data):
+def translate_coords(data,units_conv):
     cell = data["Lattice"]
     position_in = data["Positions"]
 
@@ -102,7 +112,6 @@ def translate_coords(data):
         "Positions": new_pos,
         "Translation": trans_vec,
     }
-
 
 def check_coords(cell, pos1, pos2):
     """Compares position 1 and position 2 with respect to periodic boundaries defined by cell"""

--- a/fitsnap3/scrape.py
+++ b/fitsnap3/scrape.py
@@ -159,8 +159,8 @@ def read_configs(json_folder,group_table,bispec_options):
                     f"Warning: Configuration {all_index} ({group_name}/{fname_end}) gives energy as an integer",file=sys.stderr)
                 data["Energy"] = float(data["Energy"])
 
-            units_conv = geometry.unit_conv(styles,bispec_options)
-            data["Energy"] *= units_conv[0]
+            units_conv = geometry.units_conv(styles,bispec_options)
+            data["Energy"] *= units_conv["Energy"]
             data.update(geometry.rotate_coords(data,units_conv))
             data.update(geometry.translate_coords(data,units_conv))
             if (bispec_options["compute_testerrs"] and (i > nfiles_train)): wprefac=0.0

--- a/fitsnap3/scrape.py
+++ b/fitsnap3/scrape.py
@@ -1,28 +1,28 @@
 # <!----------------BEGIN-HEADER------------------------------------>
-# ## FitSNAP3 
+# ## FitSNAP3
 # A Python Package For Training SNAP Interatomic Potentials for use in the LAMMPS molecular dynamics package
-# 
+#
 # _Copyright (2016) Sandia Corporation. Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains certain rights in this software. This software is distributed under the GNU General Public License_
 # ##
-# 
-# #### Original author: 
+#
+# #### Original author:
 #     Aidan P. Thompson, athomps (at) sandia (dot) gov (Sandia National Labs)
-#     http://www.cs.sandia.gov/~athomps 
-# 
+#     http://www.cs.sandia.gov/~athomps
+#
 # #### Key contributors (alphabetical):
 #     Mary Alice Cusentino (Sandia National Labs)
 #     Nicholas Lubbers (Los Alamos National Lab)
 #     Adam Stephens (Sandia National Labs)
 #     Mitchell Wood (Sandia National Labs)
-# 
-# #### Additional authors (alphabetical): 
+#
+# #### Additional authors (alphabetical):
 #     Elizabeth Decolvenaere (D. E. Shaw Research)
 #     Stan Moore (Sandia National Labs)
 #     Steve Plimpton (Sandia National Labs)
 #     Gary Saavedra (Sandia National Labs)
 #     Peter Schultz (Sandia National Labs)
 #     Laura Swiler (Sandia National Labs)
-#     
+#
 # <!-----------------END-HEADER------------------------------------->
 
 import os
@@ -40,7 +40,7 @@ import tqdm
 
 from . import geometry
 
-kb=0.00008617333262145
+
 group_types = (
     ('name',str),
     ('size',float),
@@ -72,7 +72,10 @@ def read_configs(json_folder,group_table,bispec_options):
     BOLTZT = bispec_options["BOLTZT"]
     styles = collections.defaultdict(lambda: set())
     all_index = 0
-
+    if bispec_options["units"]=="real":
+        kb=0.00198198665029335
+    if bispec_options["units"]=="metal":
+        kb=0.00008617333262145
     if bispec_options["atom_style"]=="spin":
         style_vars.append("Spins")
         array_vars.append("Spins")
@@ -148,8 +151,7 @@ def read_configs(json_folder,group_table,bispec_options):
             natoms=np.shape(data["Positions"])[0]
             data["QMLattice"] = data["Lattice"]
             del data["Lattice"] # We will populate this with the lammps-normalized lattice.
-            if "Label" in data:
-                del data["Label"]   # This comment line is not that useful to keep around.
+            if "Label" in data: del data["Label"]   # This comment line is not that useful to keep around.
 
             # possibly due to JSON, some configurations have integer energy values.
             if not isinstance(data["Energy"],float):
@@ -157,12 +159,12 @@ def read_configs(json_folder,group_table,bispec_options):
                     f"Warning: Configuration {all_index} ({group_name}/{fname_end}) gives energy as an integer",file=sys.stderr)
                 data["Energy"] = float(data["Energy"])
 
-            data.update(geometry.rotate_coords(data))
-            data.update(geometry.translate_coords(data))
-            if (bispec_options["compute_testerrs"] and (i > nfiles_train)):
-                wprefac=0.0
-            else:
-                wprefac=1.0
+            units_conv = geometry.unit_conv(styles,bispec_options)
+            data["Energy"] *= units_conv[0]
+            data.update(geometry.rotate_coords(data,units_conv))
+            data.update(geometry.translate_coords(data,units_conv))
+            if (bispec_options["compute_testerrs"] and (i > nfiles_train)): wprefac=0.0
+            else: wprefac=1.0
 
             if getattr(group_info, 'eweight')>=0.0:
                     for wtype in ['eweight', 'fweight', 'vweight']:
@@ -175,7 +177,6 @@ def read_configs(json_folder,group_table,bispec_options):
             all_data.append(data)
 
             all_index += 1
-
 
     for style_name, style_set in styles.items():
         assert len(style_set) == 1, "Multiple styles ({}) for {}".format(len(style_set), style_name)


### PR DESCRIPTION
Adding kbar->bar conversion common to VASP training data. Also prints error units to screen based on lammps units type. `geometry.py` has just one hard coded conversion, will be tricky to enumerate the possible JSON-LAMMPS units conversions. Will be adding an example of how to construct JSON files from VASP outputs in a separate PR. 