### PR TITLE
adding smartweights option

### DIFF
--- a/docs/TEMPLATE.in
+++ b/docs/TEMPLATE.in
@@ -39,6 +39,7 @@ normweight = -12     # (REAL) If solver!=SVD, this is the log of the penalty ter
 normratio = 0.5	     # (REAL) If solver==ELASTIC this is ratio of the linear and quadratic penalty terms
 compute_dbvb = 1     # (BOOL) If true, fit is done on energy, forces and virials. False, only energy.
 compute_testerrs = 0 # (BOOL) If less than the full training set is used in fitting, a true value will calculate the errors on the remaining, unused training. In the output, group names are appended with CV_Train and CV_Test to designate the fitted and testing training errors.
+smartweights = 0     # (BOOL) If true, a new grouplist will be made where the weights for energies, forces, and virials are (1/N_rows) where N_rows is the number of rows per group in the A matrix.  If no grouplist is specified, smartweights will automatically be used.
 
 [PATH]
 jsonPath = JSON          # (STR) Path to the training data JSON directory

--- a/docs/TEMPLATE.in
+++ b/docs/TEMPLATE.in
@@ -39,11 +39,11 @@ normweight = -12     # (REAL) If solver!=SVD, this is the log of the penalty ter
 normratio = 0.5	     # (REAL) If solver==ELASTIC this is ratio of the linear and quadratic penalty terms
 compute_dbvb = 1     # (BOOL) If true, fit is done on energy, forces and virials. False, only energy.
 compute_testerrs = 0 # (BOOL) If less than the full training set is used in fitting, a true value will calculate the errors on the remaining, unused training. In the output, group names are appended with CV_Train and CV_Test to designate the fitted and testing training errors.
-smartweights = 0     # (BOOL) If true, a new grouplist will be made where the weights for energies, forces, and virials are (1/N_rows) where N_rows is the number of rows per group in the A matrix.  If no grouplist is specified, smartweights will automatically be used.
 
 [PATH]
 jsonPath = JSON          # (STR) Path to the training data JSON directory
 groupFile = grouplist.in # (STR) Path to the training data metadata file
+smartweights = 0     # (BOOL) If true, a new grouplist will be made where the weights for energies, forces, and virials are (1/N_rows) where N_rows is the number of rows per group in the A matrix.  If no grouplist is specified, smartweights will automatically be used.
 
 [OUTFILE]
 metrics = newsnap_metrics.csv    # (STR) Overall errors and broken down by group, weighting, and variable type.

--- a/fitsnap3/__main__.py
+++ b/fitsnap3/__main__.py
@@ -183,7 +183,7 @@ def main():
     # Set fallback values if not found in input file
     bispec_options["BOLTZT"] = cp.get("BISPECTRUM","BOLTZT",fallback='10000')
     bispec_options["compute_testerrs"] = strtobool(cp.get("MODEL","compute_testerrs",fallback=0))
-    bispec_options["smartweights"] = strtobool(cp.get("MODEL","smartweights",fallback='0'))
+    bispec_options["smartweights"] = strtobool(cp.get("PATH","smartweights",fallback='0'))
     bispec_options["units"] = cp.get("REFERENCE","units",fallback='metal').lower()
     bispec_options["atom_style"] = cp.get("REFERENCE","atom_style",fallback='atomic').lower()
 

--- a/fitsnap3/__main__.py
+++ b/fitsnap3/__main__.py
@@ -183,6 +183,7 @@ def main():
     # Set fallback values if not found in input file
     bispec_options["BOLTZT"] = cp.get("BISPECTRUM","BOLTZT",fallback='10000')
     bispec_options["compute_testerrs"] = strtobool(cp.get("MODEL","compute_testerrs",fallback=0))
+    bispec_options["smartweights"] = strtobool(cp.get("MODEL","smartweights",fallback='0'))
     bispec_options["units"] = cp.get("REFERENCE","units",fallback='metal').lower()
     bispec_options["atom_style"] = cp.get("REFERENCE","atom_style",fallback='atomic').lower()
 
@@ -194,13 +195,19 @@ def main():
 
     bispec_options["pair_func"] = lmp_pairdecl
     bispec_options["verbosity"] = args.verbose
-    #print(bispec_options)
     #Get group info
     group_file = cp.get("PATH","groupFile",fallback='grouplist.in')
     group_file = os.path.join(base_path, group_file)
-    group_table = scrape.read_groups(group_file)
-    vprint("Group table:")
-    vprint(group_table)
+    if ( bispec_options["smartweights"] ) or ( ( not bispec_options["smartweights"] ) and  ( not os.path.exists(group_file) ) ):
+        if not os.path.exists(group_file):
+            print("WARNING: No grouplist file specified.")
+        json_directory = cp["PATH"]["jsonPath"]
+        group_table = scrape.create_smartweights_grouplist(base_path,json_directory)
+
+    else:
+         group_table = scrape.read_groups(group_file)
+         vprint("Group table:")
+         vprint(group_table)
 
     with printdoing("Scraping Configurations",end='\n'):
         json_directory = cp["PATH"]["jsonPath"]


### PR DESCRIPTION
I have added a new option to use "smartweights" as opposed to weights in the grouplist file.  If used, the force, energy, and virial group weights are now inversely proportional to the number of rows present in the A matrix.  So for energy, force, and virials the smartweights for each group are:

energy ~ 1/(num_configurations)
forces~ 1/(num_atoms*3)
virials ~ 1/(num_configurations*6)

where num_configurations are the total number of configurations for each group and num_atoms is the total number of atoms across all configurations in each group.  

The default is to have smartweights off.  However, if smartweights are off and there is no grouplist defined, fitsnap will automatically use smartweights and create the grouplist for you.

I tested this for both Ta and W-Be by first creating a grouplist by hand that has the same weighting and generating a potential using the by hand grouplist and the smartweights option grouplist.  I got similar snapcoeff files for both cases (< ~7th decimal place was the same)