### PR TITLE
Clean Cross Validation

### DIFF
--- a/fitsnap3/__main__.py
+++ b/fitsnap3/__main__.py
@@ -95,7 +95,8 @@ def get_filenames(base_path,allow_exists,configs=None,metrics=None,potential=Non
 
     fnameinfo ={
         "config":(configfile,'b'),
-        "metrics":(metricfile,'t'),
+        "metrics_train":(metricfile + '_train','t'),
+        "metrics_test":(metricfile + '_test','t'),
         "snapparam":(potentialname and potentialname + '.snapparam','t'),  # Keeps None if already None
         "snapcoeff":(potentialname and potentialname + '.snapcoeff','t'),
     }
@@ -182,7 +183,7 @@ def main():
 
     # Set fallback values if not found in input file
     bispec_options["BOLTZT"] = cp.get("BISPECTRUM","BOLTZT",fallback='10000')
-    bispec_options["compute_testerrs"] = strtobool(cp.get("MODEL","compute_testerrs",fallback=0))
+    bispec_options["compute_testerrs"] = cp.get("MODEL","compute_testerrs",fallback=0)
     bispec_options["smartweights"] = strtobool(cp.get("PATH","smartweights",fallback='0'))
     bispec_options["units"] = cp.get("REFERENCE","units",fallback='metal').lower()
     bispec_options["atom_style"] = cp.get("REFERENCE","atom_style",fallback='atomic').lower()
@@ -212,9 +213,9 @@ def main():
     with printdoing("Scraping Configurations",end='\n'):
         json_directory = cp["PATH"]["jsonPath"]
         json_directory = os.path.join(base_path, json_directory)
-        configs,style_info = scrape.read_configs(json_directory, group_table,bispec_options)
+        configs,test_configs,style_info = scrape.read_configs(json_directory, group_table,bispec_options)
 
-    with printdoing("Computing bispectrum data",end='\n'):
+    with printdoing("Computing training bispectrum data",end='\n'):
         configs = deploy.compute_bispec_datasets(configs,
                                                         bispec_options,
                                                         n_procs=args.jobs,
@@ -235,7 +236,7 @@ def main():
                 solver = linearfit.get_solver_fn(**cp["MODEL"])
                 fit_coeffs, solver_info = linearfit.solve_linear_snap(A,b,w, solver=solver, offset=offset)
 
-            with printdoing("Measuring errors"):
+            with printdoing("Measuring training errors"):
                 error_metrics = linearfit.group_errors(fit_coeffs,configs,bispec_options,subsystems=subsystems)
                 configs.update(linearfit.get_residuals(fit_coeffs,configs,subsystems=subsystems))
             print("Units for reported errors:")
@@ -247,12 +248,12 @@ def main():
             if args.verbose:
                 print_error_summary(error_metrics)
 
-            with optional_write(*fnameinfo["metrics"]) as file:
-                error_metrics.to_csv(file)
             with optional_write(*fnameinfo["snapparam"]) as file:
                 file.write(serialize.to_param_string(**bispec_options))
             with optional_write(*fnameinfo["snapcoeff"]) as file:
                 file.write(serialize.to_coeff_string(fit_coeffs, bispec_options))
+            with optional_write(*fnameinfo["metrics_train"]) as file:
+                error_metrics.to_csv(file)
 
     except Exception as e:
         print("Fitting interrupted! Attempting to save computed data.",file=sys.stderr)
@@ -261,7 +262,28 @@ def main():
         save_dict = {"configs": configs,"bispec_otions": bispec_options,"styles": style_info}
 #        with optional_write(*fnameinfo["config"]) as pfile:
 #            pickle.dump(save_dict, pfile, protocol=pickle.DEFAULT_PROTOCOL)
+    if float(bispec_options["compute_testerrs"]) > 0:
 
+        test_configs = deploy.compute_bispec_datasets(test_configs,
+                                                    bispec_options,
+                                                    n_procs=args.jobs,
+                                                    mpi=args.mpi,
+                                                    log=args.lammpslog)
+        test_configs = serialize.pack(test_configs)
+
+        with printdoing("Assembling linear system"):
+            offset = not bispec_options["bzeroflag"]
+            subsystems = (True,True,True) if bispec_options["compute_dbvb"] else (True,False,False)
+            A, b, w = linearfit.make_Abw(configs=test_configs, offset=offset, return_subsystems=False,subsystems=subsystems)
+
+        with printdoing("Measuring training errors"):
+            error_metrics = linearfit.group_errors(fit_coeffs,test_configs,bispec_options,subsystems=subsystems)
+            test_configs.update(linearfit.get_residuals(fit_coeffs,test_configs,subsystems=subsystems))
+        if args.verbose:
+            print_error_summary(error_metrics)
+
+        with optional_write(*fnameinfo["metrics_test"]) as file:
+            error_metrics.to_csv(file)
     return
 
 if __name__ == "__main__":

--- a/fitsnap3/deploy.py
+++ b/fitsnap3/deploy.py
@@ -58,8 +58,8 @@ def compute_bispec_datasets(input_configs, bispec_options, n_procs, mpi=False,ch
         else:
             compute_function = compute_multi
         results = compute_function(input_configs, bispec_options, n_procs, chunk_size, log=log)
-    assert all(i==j==data["Index"] for i,(j,data) in enumerate(results)),\
-        "Configurations dropped or out of order"
+    # assert all(i==j==data["Index"] for i,(j,data) in enumerate(results)),\
+    #     "Configurations dropped or out of order"
     return results
 
 ### Compute using single process

--- a/fitsnap3/linearfit.py
+++ b/fitsnap3/linearfit.py
@@ -1,28 +1,28 @@
 # <!----------------BEGIN-HEADER------------------------------------>
-# ## FitSNAP3 
+# ## FitSNAP3
 # A Python Package For Training SNAP Interatomic Potentials for use in the LAMMPS molecular dynamics package
-# 
+#
 # _Copyright (2016) Sandia Corporation. Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains certain rights in this software. This software is distributed under the GNU General Public License_
 # ##
-# 
-# #### Original author: 
+#
+# #### Original author:
 #     Aidan P. Thompson, athomps (at) sandia (dot) gov (Sandia National Labs)
-#     http://www.cs.sandia.gov/~athomps 
-# 
+#     http://www.cs.sandia.gov/~athomps
+#
 # #### Key contributors (alphabetical):
 #     Mary Alice Cusentino (Sandia National Labs)
 #     Nicholas Lubbers (Los Alamos National Lab)
 #     Adam Stephens (Sandia National Labs)
 #     Mitchell Wood (Sandia National Labs)
-# 
-# #### Additional authors (alphabetical): 
+#
+# #### Additional authors (alphabetical):
 #     Elizabeth Decolvenaere (D. E. Shaw Research)
 #     Stan Moore (Sandia National Labs)
 #     Steve Plimpton (Sandia National Labs)
 #     Gary Saavedra (Sandia National Labs)
 #     Peter Schultz (Sandia National Labs)
 #     Laura Swiler (Sandia National Labs)
-#     
+#
 # <!-----------------END-HEADER------------------------------------->
 
 import numpy as np
@@ -108,7 +108,12 @@ def make_Abw(configs, offset, return_subsystems=True,subsystems=(True,True,True)
             return submatrices[0]
 
     A, b, w = map(np.concatenate,zip(*submatrices))
-
+    # np.save('a.out',A)
+    # np.save('b.out',b)
+    # np.save('w.out',w)
+    #A_load=np.load('../FitSNAP2/A.out.npy')
+    #A=np.reshape(A_fs2,(np.shape(A_fs2)[0],1,np.shape(A_fs2)[1]))
+    #b=np.load('../FitSNAP2/b.out.npy')
     if return_subsystems:
         return ((A, b, w), *submatrices)
     return A,b,w
@@ -244,25 +249,6 @@ def group_errors(x, configs,bispec_options,subsystems=(True,True,True)):
                 error_record["Subsystem"] = gtype
                 error_record["Weighting"] = wtype
                 all_records.append(error_record)
-                if bispec_options["compute_testerrs"] and (wtype=="Weighted"):
-                    # Special Case of weighted vector for Training Set
-                    A,b,_ = subsys
-                    for i in range(len(w)):
-                        if w[i]>0.0:w[i]=1.0
-                        else:w[i]=0.0
-                    error_record = get_error_metrics(x, A,b,w)
-                    error_record["Group"] = gname
-                    error_record["Subsystem"] = gtype
-                    error_record["Weighting"] = "CVTrain_Unweight"
-                    all_records.append(error_record)
-                    # Special Case of weighted vector for Test Set
-                    A,b,_ = subsys
-                    w=abs(1-w)# w=0.0 for fitted training, =1.0 for test
-                    error_record = get_error_metrics(x, A,b,w)
-                    error_record["Group"] = gname
-                    error_record["Subsystem"] = gtype
-                    error_record["Weighting"] = "CVTest_Unweight"
-                    all_records.append(error_record)
 
     all_records = pd.DataFrame.from_records(all_records)
     all_records = all_records.set_index(["Group", "Weighting", "Subsystem", ]).sort_index()
@@ -289,6 +275,7 @@ def get_solver_fn(solver,normweight=None,normratio=None,**kwargs):
     if normratio is not None: normratio = float(normratio)
     solver_fndict = {
         "SVD": sp.linalg.lstsq,
+        #sklearn_model_to_fn(skl.linear_model.LinearRegression,),
         "LASSO":
             sklearn_model_to_fn(skl.linear_model.Lasso,
                                 alpha=normweight,max_iter=1E6,fit_intercept=False),

--- a/fitsnap3/runlammps.py
+++ b/fitsnap3/runlammps.py
@@ -1,28 +1,28 @@
 # <!----------------BEGIN-HEADER------------------------------------>
-# ## FitSNAP3 
+# ## FitSNAP3
 # A Python Package For Training SNAP Interatomic Potentials for use in the LAMMPS molecular dynamics package
-# 
+#
 # _Copyright (2016) Sandia Corporation. Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains certain rights in this software. This software is distributed under the GNU General Public License_
 # ##
-# 
-# #### Original author: 
+#
+# #### Original author:
 #     Aidan P. Thompson, athomps (at) sandia (dot) gov (Sandia National Labs)
-#     http://www.cs.sandia.gov/~athomps 
-# 
+#     http://www.cs.sandia.gov/~athomps
+#
 # #### Key contributors (alphabetical):
 #     Mary Alice Cusentino (Sandia National Labs)
 #     Nicholas Lubbers (Los Alamos National Lab)
 #     Adam Stephens (Sandia National Labs)
 #     Mitchell Wood (Sandia National Labs)
-# 
-# #### Additional authors (alphabetical): 
+#
+# #### Additional authors (alphabetical):
 #     Elizabeth Decolvenaere (D. E. Shaw Research)
 #     Stan Moore (Sandia National Labs)
 #     Steve Plimpton (Sandia National Labs)
 #     Gary Saavedra (Sandia National Labs)
 #     Peter Schultz (Sandia National Labs)
 #     Laura Swiler (Sandia National Labs)
-#     
+#
 # <!-----------------END-HEADER------------------------------------->
 
 
@@ -40,7 +40,7 @@ def extract_compute_np(lmp,name,compute_style,result_type,array_shape):
     Convert a lammps compute to a numpy array.
     Assumes the compute stores floating point numbers.
     Note that the result is a view into the original memory.
-    If the result type is 0 (scalar) then conversion to numpy is 
+    If the result type is 0 (scalar) then conversion to numpy is
     skipped and a python float is returned.
 
     From LAMMPS/src/library.cpp:
@@ -48,7 +48,7 @@ def extract_compute_np(lmp,name,compute_style,result_type,array_shape):
     type = 0 for scalar, 1 for vector, 2 for array
 
     """
-    ptr = lmp.extract_compute(name, compute_style, result_type) 
+    ptr = lmp.extract_compute(name, compute_style, result_type)
     if result_type == 0: return ptr # No casting needed, lammps.py already works
     if result_type == 2: ptr = ptr.contents
     total_size = np.prod(array_shape)
@@ -122,7 +122,7 @@ def set_computes(lmp, bispec_options):
             "quadraticflag": "quadraticflag",
             "switchflag": "switchflag",
             "alloyflag": "alloyflag",
-            "wselfallflag": "wselfallflag",
+#            "wselfallflag": "wselfallflag",
         }.items()
         if v in bispec_options
     }

--- a/fitsnap3/scrape.py
+++ b/fitsnap3/scrape.py
@@ -158,7 +158,8 @@ def read_configs(json_folder,group_table,bispec_options):
         print(nfiles_train,nfiles_test)
         for i, fname_end in tqdm.tqdm(enumerate(folder_files),
                                       desc="Configs",position=1,leave=False,total=(nfiles_train+nfiles_test),disable=(not bispec_options["verbosity"]), ascii=True):
-
+            if (i>(nfiles_train + nfiles_test)):
+                    break
             fname = os.path.join(folder, fname_end)
 
             with open(fname) as file:

--- a/fitsnap3/scrape.py
+++ b/fitsnap3/scrape.py
@@ -73,9 +73,9 @@ def create_smartweights_grouplist(base_path,json_directory):
                     data = json.loads(file.read(),parse_constant=True)
                 except Exception as e:
                      print("Trouble Parsing Training Data: ",fname)
-                     raise e   
+                     raise e
                 current_num_atoms = float(data['Dataset']['Data'][0]['NumAtoms'])
-                num_atoms_group += current_num_atoms   
+                num_atoms_group += current_num_atoms
         group_name = group
         group_size = num_files
         group_eweight = float(1/num_files)
@@ -87,8 +87,8 @@ def create_smartweights_grouplist(base_path,json_directory):
         group_table.at[row_count, 'fweight'] = group_fweight
         group_table.at[row_count, 'vweight'] = group_vweight
 
-        row_count += 1      
-    
+        row_count += 1
+
     new_grouplist_path = os.path.join(base_path,'grouplist_smartweights.in')
     new_grouplist_file = open(new_grouplist_path,'w')
     new_grouplist_file.write("#   Grouplist generated using smartweights" + '\n' + '#')
@@ -96,9 +96,8 @@ def create_smartweights_grouplist(base_path,json_directory):
 
     new_grouplist_file.close()
 
-    print("Generating new group weights using smartweights....")
+    print("Generating new group weights using smartweights...")
     print(group_table)
-    
 
     return group_table
 
@@ -119,9 +118,11 @@ def read_groups(group_file):
 
 def read_configs(json_folder,group_table,bispec_options):
     all_data = []
+    test_data = []
     BOLTZT = bispec_options["BOLTZT"]
     styles = collections.defaultdict(lambda: set())
     all_index = 0
+    test_index = 0
     if bispec_options["units"]=="real":
         kb=0.00198198665029335
     if bispec_options["units"]=="metal":
@@ -140,28 +141,23 @@ def read_configs(json_folder,group_table,bispec_options):
 #        assert len(files) == group_info.size, \
 #        ("Found a different number of files than what is defined in grouplist.in", group_name)
         #print(group_name)
+
         if group_info.size>=1.0:
             folder_files=natsort.natsorted(os.listdir(folder))
             nfiles=len(folder_files)
             nfiles_train=nfiles
+            nfiles_test=0
             print(group_info.name,": Gathering and fitting whole training set")
         else:
-            if not bispec_options["compute_testerrs"]:
-                folder_files=sklearn.utils.shuffle(os.listdir(folder))
-                nfiles=int(abs(group_info.size)*len(folder_files))
-                nfiles_train=nfiles
-                print(group_info.name,": Gathering ",nfiles ,", fitting all of this training subset")
-            else:
-                folder_files=sklearn.utils.shuffle(os.listdir(folder))
-                nfiles=len(folder_files)
-                nfiles_train=max(1,int(abs(group_info.size)*len(folder_files)-0.5))
-                print(group_info.name,": Gathering ",nfiles ," fitting on ",nfiles_train)
+            folder_files=sklearn.utils.shuffle(os.listdir(folder))
+            nfiles=len(folder_files)
+            nfiles_train=max(1,int(abs(group_info.size)*len(folder_files)-0.5))
+            nfiles_test=max(1,int(float(bispec_options["compute_testerrs"])*len(folder_files)-0.5))
             # Rather than sorting, can randomize the list and only take the top X% of training
         #print(group_info.name,nfiles)
+        print(nfiles_train,nfiles_test)
         for i, fname_end in tqdm.tqdm(enumerate(folder_files),
-                                      desc="Configs",position=1,leave=False,total=nfiles,disable=(not bispec_options["verbosity"]), ascii=True):
-            if i==nfiles:
-                break
+                                      desc="Configs",position=1,leave=False,total=(nfiles_train+nfiles_test),disable=(not bispec_options["verbosity"]), ascii=True):
 
             fname = os.path.join(folder, fname_end)
 
@@ -213,22 +209,28 @@ def read_configs(json_folder,group_table,bispec_options):
             data["Energy"] *= units_conv["Energy"]
             data.update(geometry.rotate_coords(data,units_conv))
             data.update(geometry.translate_coords(data,units_conv))
-            if (bispec_options["compute_testerrs"] and (i > nfiles_train)): wprefac=0.0
-            else: wprefac=1.0
 
             if getattr(group_info, 'eweight')>=0.0:
                     for wtype in ['eweight', 'fweight', 'vweight']:
-                        data[wtype] = wprefac*getattr(group_info, wtype)
+                        data[wtype] = getattr(group_info, wtype)
             else:
-                data['eweight'] = wprefac*np.exp((getattr(group_info, 'eweight')-data["Energy"]/float(natoms))/(kb*float(bispec_options["BOLTZT"])))
-                data['fweight'] = wprefac*data['eweight']*getattr(group_info, 'fweight')
-                data['vweight'] = wprefac*data['eweight']*getattr(group_info, 'vweight')
+                data['eweight'] = np.exp((getattr(group_info, 'eweight')-data["Energy"]/float(natoms))/(kb*float(bispec_options["BOLTZT"])))
+                data['fweight'] = data['eweight']*getattr(group_info, 'fweight')
+                data['vweight'] = data['eweight']*getattr(group_info, 'vweight')
 
-            all_data.append(data)
-
-            all_index += 1
+            if i<nfiles_train:
+                all_data.append(data)
+                all_index += 1
+            elif (i==nfiles_train and nfiles_test==0):
+                all_data.append(data)
+                all_index += 1
+                test_data.append(data)
+                test_index += 1
+            else:
+                test_data.append(data)
+                test_index += 1
 
     for style_name, style_set in styles.items():
         assert len(style_set) == 1, "Multiple styles ({}) for {}".format(len(style_set), style_name)
 
-    return all_data, {k:v.pop() for k,v in styles.items()}
+    return all_data, test_data, {k:v.pop() for k,v in styles.items()}


### PR DESCRIPTION
Changed the way training and testing errors are computed.
Previously, the ||wAb-y|| problem contained both training and testing data but with w=0 for test data. Now it A and y are only constructed for the training set, the resulting b solution is then applied to a new A and y corresponding to the test data (no fit performed). 
There are now two metrics files printed, *_train *_test, self explanatory.
Grouplist file defines the training fraction, compute_testerrs of the input file defines the test fraction. 

wselfallflag (line 125 of runlammps.py) currently disabled since the LAMMPS master branch does not reflect this capability yet. 