### PR TITLE
Fix chemsnap + bzeroflag=0 bug

### DIFF
--- a/fitsnap3/io/sections/bispectrum.py
+++ b/fitsnap3/io/sections/bispectrum.py
@@ -60,8 +60,6 @@ class Bispectrum(Section):
 #                            i += 1
 #                            self.blist.append([i, j1, j2, j])
         for atype in range(self.numtypes):
-            if not self.bzeroflag:
-                self.blank2J.append([1.0])
             for j1 in range(int(max(self.twojmax)) + 1):
                 for j2 in range(j1 + 1):
                     for j in range(abs(j1 - j2), min(int(max(self.twojmax)), j1 + j2) + 1, 2):
@@ -92,6 +90,9 @@ class Bispectrum(Section):
                            enumerate(combinations_with_replacement(self.blist, r=2), start=len(self.blist))]
         self.ncoeff = int(len(self.blist)/self.numtypes)
         if not self.bzeroflag:
+            self.blank2J = np.reshape(self.blank2J, (self.numtypes, int(len(self.blist)/self.numtypes)))
+            onehot_atoms = np.zeros((self.numtypes, 1))
+            self.blank2J = np.concatenate((onehot_atoms, self.blank2J), axis=1)
             self.blank2J = np.reshape(self.blank2J, (len(self.blist) + self.numtypes))
         else:
             self.blank2J = np.reshape(self.blank2J, len(self.blist))

--- a/fitsnap3/io/sections/bispectrum.py
+++ b/fitsnap3/io/sections/bispectrum.py
@@ -91,7 +91,7 @@ class Bispectrum(Section):
         self.ncoeff = int(len(self.blist)/self.numtypes)
         if not self.bzeroflag:
             self.blank2J = np.reshape(self.blank2J, (self.numtypes, int(len(self.blist)/self.numtypes)))
-            onehot_atoms = np.zeros((self.numtypes, 1))
+            onehot_atoms = np.ones((self.numtypes, 1))
             self.blank2J = np.concatenate((onehot_atoms, self.blank2J), axis=1)
             self.blank2J = np.reshape(self.blank2J, (len(self.blist) + self.numtypes))
         else:

--- a/fitsnap3/scrapers/scrape.py
+++ b/fitsnap3/scrapers/scrape.py
@@ -96,6 +96,8 @@ class Scraper:
             if training_size < 1 or (training_size == 1 and size_type == float):
                 if training_size == 1:
                     training_size = abs(training_size) * len(folder_files)
+                elif training_size == 0:
+                    pass
                 else:
                     training_size = max(1, int(abs(training_size) * len(folder_files) - 0.5))
                 if bc_bool and testing_size == 0:
@@ -294,7 +296,10 @@ class Scraper:
                     if self.data['test_bool']:
                         self.data[key] /= self.group_table[self.data['Group']]['testing_size']
                     else:
-                        self.data[key] /= self.group_table[self.data['Group']]['training_size']
+                        try:
+                            self.data[key] /= self.group_table[self.data['Group']]['training_size']
+                        except ZeroDivisionError:
+                            self.data[key] = 0
             if config.sections["CALCULATOR"].force:
                 self.data['fweight'] /= natoms*3
 

--- a/fitsnap3/scrapers/xyz_scraper.py
+++ b/fitsnap3/scrapers/xyz_scraper.py
@@ -356,6 +356,8 @@ class XYZ(Scraper):
             if training_size < 1 or (training_size == 1 and size_type == float):
                 if training_size == 1:
                     training_size = abs(training_size) * nconfigs
+                elif training_size == 0:
+                    pass
                 else:
                     training_size = max(1, int(abs(training_size) * nconfigs - 0.5))
                 if bc_bool and testing_size == 0:

--- a/fitsnap3/scrapers/xyz_scraper.py
+++ b/fitsnap3/scrapers/xyz_scraper.py
@@ -350,7 +350,8 @@ class XYZ(Scraper):
                             fp.write(" {}".format(item))
                         fp.write("\n")
 
-            shuffle(self.configs[file_base], pt.get_seed)
+            if config.sections["GROUPS"].random_sampling:
+                shuffle(self.configs[file_base], pt.get_seed)
             nconfigs = len(self.configs[file_base])
             if training_size < 1 or (training_size == 1 and size_type == float):
                 if training_size == 1:


### PR DESCRIPTION
Add one hot column to blank2J after chem snap multiplication to preserve number of elements in blank2J w/ chem snap.