### PR TITLE
add outside communicator using specific ADDED_COMM

### DIFF
--- a/fitsnap3/parallel_tools.py
+++ b/fitsnap3/parallel_tools.py
@@ -132,7 +132,10 @@ class ParallelTools:
 
     def __init__(self):
         if stubs == 0:
-            self._comm = MPI.COMM_WORLD
+            try:
+                self._comm = MPI.ADDED_COMM
+            except NameError:
+                self._comm = MPI.COMM_WORLD
             self._rank = self._comm.Get_rank()
             self._size = self._comm.Get_size()
         if stubs == 1:


### PR DESCRIPTION
Example use case `run_fitsnap.py`
`$ cat run_fitsnap.py`
```from runpy import run_module
from mpi4py import MPI
import sys

comm = MPI.COMM_WORLD
rank = comm.Get_rank()

color = rank % 2
local_comm = comm.Split(color)
MPI.ADDED_COMM = local_comm

original_arguments = sys.argv[0]
new_arguments = ['fitsnap3', 'Ta-example.in', '--overwrite']
sys.argv = new_arguments

if color == 0:
    run_module(sys.argv[0], run_name='__main__', alter_sys=False)
    module_list = []
    for module in sys.modules:
        if 'fitsnap' in module:
            module_list.append(module)
    for module in module_list:
        del sys.modules[module]
    run_module(sys.argv[0], run_name='__main__', alter_sys=True)

sys.argv = original_arguments
```
change directory to `/path/to/fitsnap3/examples/Ta_Linear_JCP2014`
`$ mpirun -n 4 python /path/to/run_fitsnap.py`