### PR TITLE
mliappy lammps-python enabled.

### DIFF
--- a/fitsnap3/parallel_tools.py
+++ b/fitsnap3/parallel_tools.py
@@ -32,6 +32,7 @@
 from time import time, sleep
 import numpy as np
 from lammps import lammps
+from lammps.mliap import activate_mliappy
 from random import random
 from psutil import virtual_memory
 from itertools import chain
@@ -330,8 +331,12 @@ class ParallelTools:
             cmds.append("none")
         if stubs == 0:
             self._lmp = lammps(comm=self._micro_comm, cmdargs=cmds)
+            if 'ML-IAP' in self._lmp.installed_packages:
+                activate_mliappy(self._lmp)
         else:
             self._lmp = lammps(cmdargs=cmds)
+            if 'ML-IAP' in self._lmp.installed_packages:
+                activate_mliappy(self._lmp)
 
         if printlammps == 1:
             self._lmp.command = print_lammps(self._lmp.command)


### PR DESCRIPTION
These additions are for enabling the mliappy pair style model as a reference potential.
https://docs.lammps.org/pair_mliap.html