### PR TITLE
Output fix with PyTorch.

### DIFF
--- a/fitsnap3/fitsnap.py
+++ b/fitsnap3/fitsnap.py
@@ -80,4 +80,7 @@ class FitSnap:
     def write_output(self):
         if not config.args.perform_fit:
             return
-        output.output(self.solver.fit, self.solver.errors)
+        # Prevent Output from trying to process non-existing solver.fit when using PyTorch.
+        if (config.sections["SOLVER"].solver != "PYTORCH"):
+            print("------------")
+            output.output(self.solver.fit, self.solver.errors)

--- a/fitsnap3/fitsnap.py
+++ b/fitsnap3/fitsnap.py
@@ -82,5 +82,4 @@ class FitSnap:
             return
         # Prevent Output from trying to process non-existing solver.fit when using PyTorch.
         if (config.sections["SOLVER"].solver != "PYTORCH"):
-            print("------------")
             output.output(self.solver.fit, self.solver.errors)

--- a/fitsnap3/solvers/solver.py
+++ b/fitsnap3/solvers/solver.py
@@ -54,6 +54,8 @@ class Solver:
         for key in pt.fitsnap_dict.keys():
             if isinstance(pt.fitsnap_dict[key], list) and len(pt.fitsnap_dict[key]) == len(self.df.index):
                 self.df[key] = pt.fitsnap_dict[key]
+        if config.sections["EXTRAS"].dump_dataframe:
+            self.df.to_pickle(config.sections['EXTRAS'].dataframe_file)
         for option in ["Unweighted", "Weighted"]:
             self.weighted = option
             self._all_error()


### PR DESCRIPTION
PyTorch examples will error at end of program because Output tries to process `solver.fit`, which is set to `None` when using PyTorch. Since the PyTorch module uses its own scheme for outputting model parameters, we can prevent the usual FitSNAP output from occurring for now.

There are other ways to fix this, curious if preventing Output is a bad idea. 