### PR TITLE
Add inner cutoff options in bispectrum calculator.

### DIFF
--- a/fitsnap3/calculators/lammps_snap.py
+++ b/fitsnap3/calculators/lammps_snap.py
@@ -145,6 +145,9 @@ class LammpsSnap(Calculator):
                 "bnormflag": "bnormflag",
                 "wselfallflag": "wselfallflag",
                 "bikflag": "bikflag",
+                "switchinnerflag": "switchinnerflag",
+                "sinner": "sinner",
+                "dinner": "dinner",
             }.items()
             if v in config.sections["BISPECTRUM"].__dict__
         }

--- a/fitsnap3/io/sections/calculator_sections/bispectrum.py
+++ b/fitsnap3/io/sections/calculator_sections/bispectrum.py
@@ -9,7 +9,8 @@ class Bispectrum(Section):
         super().__init__(name, config, args)
 
         self.allowedkeys = ['numTypes', 'twojmax', 'rcutfac', 'rfac0', 'rmin0', 'wj', 'radelem', 'type',
-                            'wselfallflag', 'chemflag', 'bzeroflag', 'quadraticflag', 'bnormflag', 'bikflag']
+                            'wselfallflag', 'chemflag', 'bzeroflag', 'quadraticflag', 'bnormflag', 'bikflag',
+                            'switchinnerflag', 'sinner', 'dinner']
         self._check_section()
 
         self._check_if_used("CALCULATOR", "calculator", "LAMMPSSNAP", "LAMMPSSNAP")
@@ -49,6 +50,15 @@ class Bispectrum(Section):
         self._generate_b_list()
         self._reset_chemflag()
         Section.num_desc = len(self.blist)
+        # switchinnerflag true enables inner cutoff function
+        self.switchinnerflag = self.get_value("BISPECTRUM", "switchinnerflag", "0", "bool")
+        if (self.switchinnerflag):
+            default_sinner = self.numtypes*"0.9 "
+            default_dinner = self.numtypes*"0.1 "
+            self.sinner = self.get_value("BISPECTRUM", "sinner", default_sinner[:-1], "str")
+            self.dinner = self.get_value("BISPECTRUM", "dinner", default_dinner[:-1], "str")
+            if ( (len(self.sinner.split()) != self.numtypes) or (len(self.dinner.split()) != self.numtypes)):
+                raise ValueError("Number of sinner/dinner args must be number of types.")
         self.delete()
 
     def _generate_b_list(self):

--- a/fitsnap3/io/sections/solver_sections/pytorch.py
+++ b/fitsnap3/io/sections/solver_sections/pytorch.py
@@ -33,7 +33,19 @@ try:
 except ModuleNotFoundError:
 
     class PYTORCH(Section):
-
+        """
+        Dummy class for factory to read if torch is not available for import.
+        """
         def __init__(self, name, config, args):
             super().__init__(name, config, args)
             raise ModuleNotFoundError("No module named 'torch'")
+
+except NameError:
+
+    class PYTORCH(Section):
+        """
+        Dummy class for factory to read if MLIAP error is occuring.
+        """
+        def __init__(self, name, config, args):
+            super().__init__(name, config, args)
+            raise NameError("MLIAP error.")

--- a/fitsnap3/solvers/jax.py
+++ b/fitsnap3/solvers/jax.py
@@ -8,9 +8,9 @@ from time import time
 import pickle
 
 try:
+    from ..lib.neural_networks.pytorch import create_torch_network, FitTorch
     from ..lib.neural_networks.jax import jnp, loss, accuracy, mae, jit, grad, adam, apply_updates
     from ..tools.dataloaders import InRAMDatasetJAX, DataLoader, jax_collate
-
 
     class JAX(Solver):
 
@@ -109,7 +109,7 @@ try:
                     pickle.dump(self.opt_state, fp)
 
         def create_pytorch(self):
-            from ..lib.neural_networks.pytorch import create_torch_network, FitTorch
+            #from ..lib.neural_networks.pytorch import create_torch_network, FitTorch
 
             pytorch_network = create_torch_network(config.sections["JAX"].layer_sizes)
             pytorch_model = FitTorch(pytorch_network, config.sections["CALCULATOR"].num_desc)
@@ -120,7 +120,7 @@ try:
             pytorch_model.write_lammps_torch(config.sections["JAX"].output_file)
 
         def load_pytorch(self):
-            from ..lib.neural_networks.pytorch import create_torch_network, FitTorch
+            #from ..lib.neural_networks.pytorch import create_torch_network, FitTorch
 
             pytorch_network = create_torch_network(config.sections["JAX"].layer_sizes)
             pytorch_model = FitTorch(pytorch_network, config.sections["CALCULATOR"].num_desc)
@@ -142,3 +142,13 @@ except ModuleNotFoundError:
         def __init__(self, name):
             super().__init__(name)
             raise ModuleNotFoundError("No module named 'JAX'")
+
+except NameError:
+
+    class JAX(Solver):
+        """
+        Dummy class for factory to read if MLIAP error is occuring.
+        """
+        def __init__(self, name):
+            super().__init__(name)
+            raise NameError("MLIAP error.")

--- a/fitsnap3/solvers/pytorch.py
+++ b/fitsnap3/solvers/pytorch.py
@@ -161,3 +161,13 @@ except ModuleNotFoundError:
         def __init__(self, name):
             super().__init__(name)
             raise ModuleNotFoundError("No module named 'Pytorch'")
+
+except NameError:
+
+    class Pytorch(Solver):
+        """
+        Dummy class for factory to read if MLIAP error is occuring.
+        """
+        def __init__(self, name):
+            super().__init__(name)
+            raise NameError("MLIAP error.")


### PR DESCRIPTION
Inner cutoff keywords can now be used in input scripts, e.g. for two atom types:

```
[BISPECTRUM]   
numTypes = 2   
switchinnerflag = 1
sinner = 0.9 0.9
dinner = 0.1 0.1
```

Default values and error catching prevents misuse.