### PR TITLE
when random_sampling toggled on, always record what seed used and enable user to set seed themselves

### DIFF
--- a/fitsnap3/calculators/lammps_snap.py
+++ b/fitsnap3/calculators/lammps_snap.py
@@ -145,9 +145,9 @@ class LammpsSnap(Calculator):
                 "bnormflag": "bnormflag",
                 "wselfallflag": "wselfallflag",
                 "bikflag": "bikflag",
-                "switchinnerflag": "switchinnerflag",
-                "sinner": "sinner",
-                "dinner": "dinner",
+                # "switchinnerflag": "switchinnerflag",
+                # "sinner": "sinner",
+                # "dinner": "dinner",
             }.items()
             if v in config.sections["BISPECTRUM"].__dict__
         }

--- a/fitsnap3/calculators/lammps_snap.py
+++ b/fitsnap3/calculators/lammps_snap.py
@@ -145,9 +145,9 @@ class LammpsSnap(Calculator):
                 "bnormflag": "bnormflag",
                 "wselfallflag": "wselfallflag",
                 "bikflag": "bikflag",
-                # "switchinnerflag": "switchinnerflag",
-                # "sinner": "sinner",
-                # "dinner": "dinner",
+                "switchinnerflag": "switchinnerflag",
+                "sinner": "sinner",
+                "dinner": "dinner",
             }.items()
             if v in config.sections["BISPECTRUM"].__dict__
         }

--- a/fitsnap3/io/sections/groups.py
+++ b/fitsnap3/io/sections/groups.py
@@ -20,7 +20,7 @@ class Groups(Section):
 
     def __init__(self, name, config, args):
         super().__init__(name, config, args)
-        self.allowedkeys = ['group_sections', 'group_types', 'smartweights', 'random_sampling', 'BOLTZ']
+        self.allowedkeys = ['group_sections', 'group_types', 'smartweights', 'random_sampling', 'random_seed', 'BOLTZ']
 
         # for value_name in config['GROUPS']:
         #     if value_name in allowedkeys: continue
@@ -30,6 +30,7 @@ class Groups(Section):
         self.group_types = self.get_value("GROUPS", "group_types", "str float float float float").split()
         self.smartweights = self.get_value("GROUPS", "smartweights", "0", "bool")
         self.random_sampling = self.get_value("GROUPS", "random_sampling", "0", "bool")
+        self.random_seed = self.get_value("GROUPS", "random_seed", "0", "bool")
         self.boltz = self.get_value("BISPECTRUM", "BOLTZ", "0", "float")
         _str_2_fun(self.group_types)
         self.group_table = None

--- a/fitsnap3/io/sections/groups.py
+++ b/fitsnap3/io/sections/groups.py
@@ -30,7 +30,7 @@ class Groups(Section):
         self.group_types = self.get_value("GROUPS", "group_types", "str float float float float").split()
         self.smartweights = self.get_value("GROUPS", "smartweights", "0", "bool")
         self.random_sampling = self.get_value("GROUPS", "random_sampling", "0", "bool")
-        self.random_seed = self.get_value("GROUPS", "random_seed", "0", "bool")
+        self.random_seed = self.get_value("GROUPS", "random_seed", "0", "float")
         self.boltz = self.get_value("BISPECTRUM", "BOLTZ", "0", "float")
         _str_2_fun(self.group_types)
         self.group_table = None

--- a/fitsnap3/parallel_tools.py
+++ b/fitsnap3/parallel_tools.py
@@ -32,7 +32,7 @@
 from time import time, sleep
 import numpy as np
 from lammps import lammps
-from random import random
+from random import randint
 from psutil import virtual_memory
 from itertools import chain
 import ctypes
@@ -190,7 +190,7 @@ class ParallelTools:
 
     def _set_seed(self):
         if self._rank == 0.0:
-            self._seed = random()
+            self._seed = randint(0,1e5)
         if stubs == 0:
             self._seed = self._comm.bcast(self._seed)
 

--- a/fitsnap3/scrapers/scrape.py
+++ b/fitsnap3/scrapers/scrape.py
@@ -63,7 +63,7 @@ class Scraper:
         self.group_table = config.sections["GROUPS"].group_table
         size_type = None
         testing_size_type = None
-        user_set_random_seed = config.sections["GROUPS"].random_seed
+        user_set_random_seed = config.sections["GROUPS"].random_seed ## default is 0
 
         if config.sections["GROUPS"].random_sampling:
             output.screen(f"Random sampling of groups toggled on.")
@@ -106,15 +106,7 @@ class Scraper:
                     self.files[folder] = []
                 self.files[folder].append([folder + '/' + file_name, int(stat(folder + '/' + file_name).st_size)])
             if config.sections["GROUPS"].random_sampling:
-                db_nf = 3
-                print(f"\tDEBUG pre-shuffled, first {db_nf} and last {db_nf} files :")
-                for f in self.files[folder][:db_nf] + self.files[folder][-db_nf:]:
-                    print("\t",f)
                 shuffle(self.files[folder], random)
-                print(f"\tDEBUG post-shuffled, first {db_nf} and last {db_nf} files :")
-                for f in self.files[folder][:db_nf] + self.files[folder][-db_nf:]:
-                    print(f"\t",f)
-                exit()
             nfiles = len(folder_files)
             if training_size < 1 or (training_size == 1 and size_type == float):
                 if training_size == 1:

--- a/fitsnap3/scrapers/scrape.py
+++ b/fitsnap3/scrapers/scrape.py
@@ -69,8 +69,15 @@ class Scraper:
             output.screen(f"Random sampling of groups toggled on.")
             if not user_set_random_seed:
                 output.screen(f"FitSNAP-generated seed for random sampling: {pt.get_seed()}")
+                seed(pt.get_seed())
             else:
+                ## groups.py casts random_seed to float, just in case user
+                ## uses continuous variable. if user input was originally
+                ## an integer, this casts it to int (less confusing for user)
+                if user_set_random_seed.is_integer():
+                    user_set_random_seed = int(user_set_random_seed)
                 output.screen(f"User-set seed for random sampling: {user_set_random_seed}")
+                seed(user_set_random_seed)
 
         for key in self.group_table:
             bc_bool = False
@@ -99,16 +106,13 @@ class Scraper:
                     self.files[folder] = []
                 self.files[folder].append([folder + '/' + file_name, int(stat(folder + '/' + file_name).st_size)])
             if config.sections["GROUPS"].random_sampling:
-                print("\tDEBUG pre-shuffled, first 2 and last 2 files :")
-                for f in self.files[folder][:2] + self.files[folder][-2:]:
+                db_nf = 3
+                print(f"\tDEBUG pre-shuffled, first {db_nf} and last {db_nf} files :")
+                for f in self.files[folder][:db_nf] + self.files[folder][-db_nf:]:
                     print("\t",f)
-                if not user_set_random_seed:
-                    shuffle(self.files[folder], pt.get_seed)
-                else:
-                    seed(user_set_random_seed)
-                    shuffle(self.files[folder], random)
-                print("\tDEBUG post-shuffled, first 2 and last 2 files :")
-                for f in self.files[folder][:2] + self.files[folder][-2:]:
+                shuffle(self.files[folder], random)
+                print(f"\tDEBUG post-shuffled, first {db_nf} and last {db_nf} files :")
+                for f in self.files[folder][:db_nf] + self.files[folder][-db_nf:]:
                     print(f"\t",f)
                 exit()
             nfiles = len(folder_files)

--- a/fitsnap3/scrapers/scrape.py
+++ b/fitsnap3/scrapers/scrape.py
@@ -68,16 +68,18 @@ class Scraper:
         if config.sections["GROUPS"].random_sampling:
             output.screen(f"Random sampling of groups toggled on.")
             if not user_set_random_seed:
-                output.screen(f"FitSNAP-generated seed for random sampling: {pt.get_seed()}")
-                seed(pt.get_seed())
+                sampling_seed = pt.get_seed()
+                seed_txt = f"FitSNAP-generated seed for random sampling: {pt.get_seed()}"
             else:
                 ## groups.py casts random_seed to float, just in case user
                 ## uses continuous variable. if user input was originally
                 ## an integer, this casts it to int (less confusing for user)
                 if user_set_random_seed.is_integer():
-                    user_set_random_seed = int(user_set_random_seed)
-                output.screen(f"User-set seed for random sampling: {user_set_random_seed}")
-                seed(user_set_random_seed)
+                    sampling_seed = int(user_set_random_seed)
+                seed_txt = f"User-set seed for random sampling: {sampling_seed}"
+            output.screen(seed_txt)
+            seed(sampling_seed)
+            self._write_seed_file(seed_txt)
 
         for key in self.group_table:
             bc_bool = False
@@ -320,6 +322,11 @@ class Scraper:
 
             if config.sections["CALCULATOR"].stress:
                 self.data['fweight'] /= 6
+
+    @pt.rank_zero
+    def _write_seed_file(self, txt):
+        with open("RandomSamplingSeed.txt", 'w') as f:
+            f.write(txt+'\n')
 
     # def check_coords(self, cell, pos1, pos2):
     #     """Compares position 1 and position 2 with respect to periodic boundaries defined by cell"""

--- a/fitsnap3/scrapers/scrape.py
+++ b/fitsnap3/scrapers/scrape.py
@@ -32,7 +32,7 @@
 from ..io.input import config
 from os import path, listdir, stat
 import numpy as np
-from random import shuffle
+from random import seed, random, shuffle
 from ..parallel_tools import pt
 from ..io.output import output
 from ..units.units import convert
@@ -63,9 +63,14 @@ class Scraper:
         self.group_table = config.sections["GROUPS"].group_table
         size_type = None
         testing_size_type = None
+        user_set_random_seed = config.sections["GROUPS"].random_seed
 
         if config.sections["GROUPS"].random_sampling:
-            output.screen(f"Random sampling of groups toggled on. Seed: {pt.get_seed()}")
+            output.screen(f"Random sampling of groups toggled on.")
+            if not user_set_random_seed:
+                output.screen(f"FitSNAP-generated seed for random sampling: {pt.get_seed()}")
+            else:
+                output.screen(f"User-set seed for random sampling: {user_set_random_seed}")
 
         for key in self.group_table:
             bc_bool = False
@@ -94,7 +99,18 @@ class Scraper:
                     self.files[folder] = []
                 self.files[folder].append([folder + '/' + file_name, int(stat(folder + '/' + file_name).st_size)])
             if config.sections["GROUPS"].random_sampling:
-                shuffle(self.files[folder], pt.get_seed)
+                print("\tDEBUG pre-shuffled, first 2 and last 2 files :")
+                for f in self.files[folder][:2] + self.files[folder][-2:]:
+                    print("\t",f)
+                if not user_set_random_seed:
+                    shuffle(self.files[folder], pt.get_seed)
+                else:
+                    seed(user_set_random_seed)
+                    shuffle(self.files[folder], random)
+                print("\tDEBUG post-shuffled, first 2 and last 2 files :")
+                for f in self.files[folder][:2] + self.files[folder][-2:]:
+                    print(f"\t",f)
+                exit()
             nfiles = len(folder_files)
             if training_size < 1 or (training_size == 1 and size_type == float):
                 if training_size == 1:


### PR DESCRIPTION
when random_sampling toggled on:
- always record what seed used in text file "RandomSamplingSeed.txt"
- enable user to set seed themselves in "GROUPS" section variable "random_seed" to perfectly recreate previous fits

this version tested with serial and mpi versions on MacOS Big Sur and clusters

note: parallel_tools.py self._seed now an integer instead of float in range [0, 1.0)

future note: we may want to add a warning with user-set seed that this partially overrides functionality of random_sampling and is really intended for recreating fits