### PR TITLE
Fixed the coeff labels in InP_pot.snapcoeff

### DIFF
--- a/fitsnap3/io/outputs/snap.py
+++ b/fitsnap3/io/outputs/snap.py
@@ -86,23 +86,27 @@ def _to_coeff_string(coeffs):
     """
     Convert a set of coefficients along with bispec options into a .snapparam file
     """
-    # Includes the offset term, which was not in blist
-    # coeffs = (coeffs * config.sections["BISPECTRUM"].blank2J).reshape((config.sections["BISPECTRUM"].numtypes, -1))
-    coeffs = coeffs.reshape((config.sections["BISPECTRUM"].numtypes, -1))
-    blank2Js = config.sections["BISPECTRUM"].blank2J.reshape((config.sections["BISPECTRUM"].numtypes, -1))
+    numtypes = config.sections["BISPECTRUM"].numtypes
+    ncoeff = config.sections["BISPECTRUM"].ncoeff
+    coeffs = coeffs.reshape((numtypes, -1))
+    blank2Js = config.sections["BISPECTRUM"].blank2J.reshape((numtypes, -1))
     if config.sections["BISPECTRUM"].bzeroflag:
         blank2Js = np.insert(blank2Js, 0, [1.0], axis=1)
     coeffs = np.multiply(coeffs, blank2Js)
-    coeff_names = [[0]]+config.sections["BISPECTRUM"].blist
     type_names = config.sections["BISPECTRUM"].types
     out = f"# fitsnap fit generated on {datetime.now()}\n\n"
-    out += "{} {}\n".format(len(type_names), int(np.ceil(len(coeff_names)/config.sections["BISPECTRUM"].numtypes)))
-    for elname, rjval, wjval, column in zip(type_names,
+    out += "{} {}\n".format(len(type_names), ncoeff+1)
+
+    for elname, rjval, wjval, column, ielem in zip(type_names,
                                             config.sections["BISPECTRUM"].radelem,
                                             config.sections["BISPECTRUM"].wj,
-                                            coeffs):
+                                                    coeffs, range(numtypes)):
+        bstart = ielem * ncoeff
+        bstop = bstart + ncoeff
+        bnames = [[0]] + config.sections["BISPECTRUM"].blist[bstart:bstop]
+
         out += "{} {} {}\n".format(elname, rjval, wjval)
-        out += "\n".join(f" {bval:<30.18} #  B{bname} " for bval, bname in zip(column, coeff_names))
+        out += "\n".join(f" {bval:<30.18} #  B{bname} " for bval, bname in zip(column, bnames))
         out += "\n"
     out += "\n# End of potential"
     return out

--- a/fitsnap3/io/sections/calculator_sections/bispectrum.py
+++ b/fitsnap3/io/sections/calculator_sections/bispectrum.py
@@ -64,7 +64,6 @@ class Bispectrum(Section):
     def _generate_b_list(self):
         self.blist = []
         self.blank2J = []
-        i = 0
 # Save for when LAMMPS will accept multiple 2J
 #        for atype in range(self.numtypes):
 #            for j1 in range(int(self.twojmax[atype]) + 1):
@@ -74,6 +73,7 @@ class Bispectrum(Section):
 #                            i += 1
 #                            self.blist.append([i, j1, j2, j])
         for atype in range(self.numtypes):
+            i = 0
             for j1 in range(int(max(self.twojmax)) + 1):
                 for j2 in range(j1 + 1):
                     for j in range(abs(j1 - j2), min(int(max(self.twojmax)), j1 + j2) + 1, 2):


### PR DESCRIPTION
The labels in InP_pot.snapcoeff were wrong.  This was due to an underlying errors in how labels were both generated and written out, the first masking the second, except for EME SNAP.  For example, this line:

-0.0093682727286219878         #  B[60, 6, 6, 6]

now reads:

 -0.0093682727286241111         #  B[30, 6, 6, 6] 

 