### PR TITLE
Fix parallel tools check_fitsnap_exist variable

### DIFF
--- a/examples/library/README.md
+++ b/examples/library/README.md
@@ -1,17 +1,22 @@
 # Examples using FitSNAP library
 
-### `example1.py`
+### `extract_descriptors/example.py`
 
 Here we import all the configs in the tantalum example with FitSNAP's `scrape_configs` function.
 Then we use the `Calculator` class to compute bispectrums, bispectrum derivatives, and virials for
 all configs.
 
-### `example2.py`
+### `test_error_fit/example.py`
+
+Perform a fit and immediately calculate errors on the test set after the fit, using the dataframe
+created by FitSNAP. 
+
+### `test_error_nofit/example.py`
 
 Use the FitSNAP library to calculate errors on a test set, without performing a fit. Run this 
 example like:
 
-`python example2.py --fitsnap_in /path/to/fitsnap.in --test_dir /path/to/test_dir`
+`python example.py --fitsnap_in /path/to/fitsnap.in --test_dir /path/to/test_dir`
 
 The `--fitsnap_in` precedes the path to the FitSNAP input script that was used for fitting. This 
 ensures that we use exactly the same settings that we used when training, like units. **Nothing in
@@ -21,12 +26,12 @@ The `--test_dir` precedes the path to a directory containing test data.
 
 **Before running on your own example, change the `pairstyle` variable in this script.**
 
-### `example3.py`
+### `extract_dataframe/example.py`
 
 Use the FitSNAP library to perform a fit and extract the dataframe as a variable, which we can 
 manually calculate errors on.
 
-### `example4.py` 
+### `loop_over_fits/example.py` 
 
 Use the FitSNAP library to perform many fits in a loop, where we change hyperparams like weights
 and descriptor settings during each loop. This is a good foundation for hyperparam optimization.

--- a/examples/library/extract_dataframe/example.py
+++ b/examples/library/extract_dataframe/example.py
@@ -1,5 +1,6 @@
 """
-Python script for performing a fit using the FitSNAP library.
+Python script for performing a fit using the FitSNAP library, and extracting a dataframe of fitting
+quantities..
 
 We do this by creating a FitSNAP object and then calling the functions (see fitsnap3/__main__.py):
 
@@ -14,7 +15,7 @@ Usage:
 
 Simply run the script and supply a command line arg for the FitSNAP input file path, for example:
 
-    python example3.py --fitsnap_in ../Ta_Linear_JCP2014/Ta-example-nodump.in
+    python example.py --fitsnap_in ../../Ta_Linear_JCP2014/Ta-example-nodump.in
 """
 
 import numpy as np

--- a/examples/library/extract_descriptors/example.py
+++ b/examples/library/extract_descriptors/example.py
@@ -1,3 +1,11 @@
+"""
+Scrape all the configs in a certain directory specified by the FitSNAP input script.
+
+Usage:
+
+    python example.py
+"""
+
 import numpy as np
 from mpi4py import MPI
 
@@ -9,7 +17,7 @@ from fitsnap3lib.parallel_tools import ParallelTools
 pt = ParallelTools(comm=comm)
 # Config class reads the input
 from fitsnap3lib.io.input import Config
-config = Config(arguments_lst = ["../Ta_Linear_JCP2014/Ta-example.in", "--overwrite"])
+config = Config(arguments_lst = ["../../Ta_Linear_JCP2014/Ta-example.in", "--overwrite"])
 # create a fitsnap object
 from fitsnap3lib.fitsnap import FitSnap
 snap = FitSnap()

--- a/examples/library/loop_over_fits/example.py
+++ b/examples/library/loop_over_fits/example.py
@@ -8,7 +8,7 @@ This procedure happens in a loop and is a good foundation for implementing hyper
 
 Usage:
 
-    python example4.py --fitsnap_in ../Ta_Linear_JCP2014/Ta-example-nodump.in
+    python example.py --fitsnap_in ../../Ta_Linear_JCP2014/Ta-example-nodump.in
 """
 
 import numpy as np

--- a/examples/library/test_error_fit/example.py
+++ b/examples/library/test_error_fit/example.py
@@ -1,0 +1,169 @@
+"""
+Python script for performing a fit and immediately calculating test errors after the fit.
+
+Test errors are reported for MAE energy (eV/atom) and MAE force (eV/Angstrom), if using LAMMPS 
+metal units.
+
+Usage:
+
+    python example.py --fitsnap_in ../../Ta_Linear_JCP2014/Ta-example-nodump.in
+"""
+
+import numpy as np
+from mpi4py import MPI
+import argparse
+import gc
+
+def calc_mae_energy(df):
+
+    preds = snap.solver.df.loc[:,"preds"]
+    truths = snap.solver.df.loc[:, "truths"]
+    row_type =  snap.solver.df.loc[:, "Row_Type"]
+
+    # use Row_Type rows to count number of atoms per config
+    # see if this number matches that extracted from pt.shared_arrays
+
+    nconfigs = row_type.tolist().count("Energy")
+    natoms_per_config = np.zeros(nconfigs).astype(int)
+
+    config_indx = -1
+    for element in row_type.tolist():
+        if element=="Energy":
+            config_indx+=1
+        elif element=="Force":
+            natoms_per_config[config_indx]+=1
+        else:
+            pass 
+
+        assert (config_indx>=0)
+
+    natoms_per_config = natoms_per_config/3
+    natoms_per_config = natoms_per_config.astype(int)
+    #print(natoms_per_config)
+
+    assert ( (natoms_per_config == pt.shared_arrays["number_of_atoms"].array).all() )
+
+    row_indices = row_type[:] == "Energy"
+    row_indices = row_indices.tolist()
+
+    test_bool = snap.solver.df.loc[:, "Testing"].tolist()
+    test_row_indices = [row_indices and test_bool for row_indices, test_bool in zip(row_indices, test_bool)]
+    
+    test_truths = np.array(truths[test_row_indices])
+    num_test_components = np.shape(test_truths)[0]
+
+    test_preds = np.array(preds[test_row_indices])
+
+    # extract number of atoms for test configs
+    # need to know which configs are testing, and which are training, so we extract correct natoms
+
+    test_configs = []
+    indx=0
+    count=0
+    for element in row_type.tolist():
+        if (element=="Energy" and test_row_indices[indx]):
+            count+=1
+            test_configs.append(True)
+        if (element=="Energy" and not test_row_indices[indx]):
+            test_configs.append(False)
+        indx+=1
+    
+    assert(len(test_configs) == np.shape(natoms_per_config)[0]) 
+    assert((sum(test_row_indices) == count) and (sum(test_configs) == count) )
+
+    natoms_test = natoms_per_config[test_configs]
+    
+    diff = np.abs(test_preds - test_truths)
+    diff_per_atom = diff/natoms_test
+    mae = np.mean(diff_per_atom)
+
+    return mae
+
+def calc_mae_force(df):
+
+    preds = snap.solver.df.loc[:,"preds"]
+    truths = snap.solver.df.loc[:, "truths"]
+    row_type =  snap.solver.df.loc[:, "Row_Type"]
+
+    force_row_indices = row_type[:] == "Force"
+    force_row_indices = force_row_indices.tolist()
+
+    testing_bool = snap.solver.df.loc[:, "Testing"].tolist()
+    # use list comprehension to extract row indices that are both force and testing
+    testing_force_row_indices = [force_row_indices and testing_bool for force_row_indices, testing_bool in zip(force_row_indices, testing_bool)]
+
+    testing_force_truths = np.array(truths[testing_force_row_indices])
+    number_of_testing_force_components = np.shape(testing_force_truths)[0]
+    testing_force_truths = np.reshape(testing_force_truths, (int(number_of_testing_force_components/3), 3))
+
+    testing_force_preds = np.array(preds[testing_force_row_indices])
+    assert(np.shape(testing_force_preds)[0] == number_of_testing_force_components)
+    natoms_test = int(number_of_testing_force_components/3)
+    testing_force_preds = np.reshape(testing_force_preds, (natoms_test, 3))
+
+    diff = testing_force_preds - testing_force_truths
+    norm = np.linalg.norm(diff, axis=1)
+    mae = np.mean(norm)
+
+    return mae 
+
+# parse command line args
+
+parser = argparse.ArgumentParser(description='FitSNAP example.')
+parser.add_argument("--fitsnap_in", help="FitSNAP input script.", default=None)
+args = parser.parse_args()
+print("FitSNAP input script:")
+print(args.fitsnap_in)
+
+comm = MPI.COMM_WORLD
+
+# import parallel tools and create pt object
+# this is the backbone of FitSNAP
+from fitsnap3lib.parallel_tools import ParallelTools
+#pt = ParallelTools(comm=comm)
+pt = ParallelTools()
+# Config class reads the input
+from fitsnap3lib.io.input import Config
+config = Config(arguments_lst = [args.fitsnap_in, "--overwrite"])
+# create a fitsnap object
+from fitsnap3lib.fitsnap import FitSnap
+snap = FitSnap()
+
+# tell ParallelTool not to create SharedArrays
+pt.create_shared_bool = False
+# tell ParallelTools not to check for existing fitsnap objects
+pt.check_fitsnap_exist = False
+# tell FitSNAP not to delete the data object after processing configs
+snap.delete_data = False
+
+# scrape configs to create the snap data list
+
+snap.scraper.scrape_groups()
+snap.scraper.divvy_up_configs()
+snap.data = snap.scraper.scrape_configs()
+
+# process configs
+# set indices to zero for populating new data array
+
+snap.process_configs()
+ 
+# perform a fit and gather dataframe with snap.solver.error_analysis()
+snap.solver.perform_fit()
+snap.solver.fit_gather()
+snap.solver.error_analysis()
+
+# calculate energy error on the test set
+
+etest_mae = calc_mae_energy(snap.solver.df)
+
+# calculate force error on the test set
+
+ftest_mae = calc_mae_force(snap.solver.df)
+
+print("-----")
+print(f"Energy MAE (eV/atom): {etest_mae}")
+print(f"Force MAE (eV/Angstrom): {ftest_mae}")
+    
+
+
+

--- a/examples/library/test_error_nofit/example.py
+++ b/examples/library/test_error_nofit/example.py
@@ -6,10 +6,11 @@ Before using this script,
 
 To use this particular example script for the Ta example:
 1) Run FitSNAP on the Ta_Linear_JCP2014 example without training on some groups (e.g. the elastic 
-groups), by commenting them out in the GROUPS section.
+groups), by commenting them out in the GROUPS section. This creates a snapparam and snapcoeff file,
+that we will use here.
 2) Run this example like:
 
-python example2.py --fitsnap_in ../Ta_Linear_JCP2014/Ta-example.in --test_dir ../Ta_Linear_JCP2014/Test_Set_Example/
+python example2.py --fitsnap_in ../../Ta_Linear_JCP2014/Ta-example.in --test_dir ../../Ta_Linear_JCP2014/Test_Set_Example/
 """
 # set pair style commands
 

--- a/fitsnap3lib/parallel_tools.py
+++ b/fitsnap3lib/parallel_tools.py
@@ -160,6 +160,9 @@ def print_lammps(method):
 class ParallelTools(metaclass=Singleton):
 
     def __init__(self, comm=None):
+
+        self.check_fitsnap_exist = True # set to False if want to allow re-creating dictionary
+
         if stubs == 0:
             if comm is None:
                 comm = MPI.COMM_WORLD
@@ -169,9 +172,6 @@ class ParallelTools(metaclass=Singleton):
             self.create_shared_bool = True # set to False if want to avoid shared array
                                            # this is helpful when using the library to loop over
                                            # functions that create shared arrays, to avoid mem leaks
-            self.check_fitsnap_exist = True # set to False if want to allow re-creating dictionary
-                                            # objects in the add_2_fitsnap function
-                                            # this is useful when using library to loop over fits
 
         if stubs == 1:
             self._rank = 0


### PR DESCRIPTION
Fixes a bug that occurs when not using MPI. 

Parallel tools has a variable `self.check_fitsnap_exist` which was introduced in https://github.com/FitSNAP/FitSNAP/pull/120. This variable is a boolean setting to determine whether recreating dictionary keys is allowed, which is useful when using the library to loop over multiple fits. 

Currently `self.check_fitsnap_exist` is only declared for `stubs==0` (using MPI), but we also need to declare it when `stubs==1` (not using MPI). Otherwise we will get an error when running FitSNAP without MPI. 