### PR TITLE
updated VASP2JSON.py - skips unconverged ionic steps, records POTCARs

### DIFF
--- a/tools/VASP2JSON.py
+++ b/tools/VASP2JSON.py
@@ -10,6 +10,7 @@ import json
 OUTCAR_file = sys.argv[1]
 JSON_file = str(sys.argv[2])
 
+write_unconverged_steps_anyway = False
 
 def write_json(data, jsonfilename):
     """
@@ -40,12 +41,15 @@ def write_json(data, jsonfilename):
     myDataset = {}
 
     myDataset["Dataset"] = allDataHeader
-    sjson = json.dump(myDataset, jsonfile, indent=2, sort_keys=True)
+    #jsonfile.write(json.dumps(myDataset))  # if you want a condensed string
+    json.dump(myDataset, jsonfile, indent=2, sort_keys=True)  #if you want the expanded, multi-line format
+    jsonfile.close()
     return
 
 
 order_atom_types = []
 listAtomTypes = []
+list_POTCARS = []
 
 # Start parsing through OUTCAR looking for keywords that are assocaited with the
 # different values for the data needed, such as forces or positions
@@ -55,17 +59,24 @@ with open(OUTCAR_file, "rt") as f2:
 outcar_config_number = 1
 
 for i, line in enumerate(lines):
-    # Look for the ordering of the atom types
-    # can grab atom labels from VRHFIN lines at top of OUTCAR
-    # (These will only show up once for each element at in the OUTCAR)
-    if "VRHFIN" in line:
+    # Look for the ordering of the atom types - grabbing POTCAR filenames first, then atom labels separately because VASP has terribly inconsistent formatting
+    if "POTCAR:" in line:
+        if (
+            line.split()[1:] not in list_POTCARS
+        ):  # VASP will have these lines in the OUTCAR twice, and we don't need to append them the second time
+            list_POTCARS.append(
+                line.split()[1:]
+            )  # each line will look something like ['PAW_PBE', 'Zr_sv_GW', '05Dec2013']
+    # can grab atom labels from VRHFIN lines at top of OUTCAR - much more consistent formatting than the POTCAR names
+    # (These will only show up once for each element type in the OUTCAR)
+    elif "VRHFIN" in line:
         order_atom_types.append(line.split()[1][1:].strip(" :"))
     # Look for number of atoms in configuration
-    if "number of ions" in line:
+    elif "number of ions" in line:
         columns = line.split()
         natoms = int(columns[11])
     # Look for the number of atoms of each element type in configuration
-    if "ions per type =" in line:
+    elif "ions per type =" in line:
         num_atoms_per_type = [int(num) for num in line.split()[4:]]
         num_atom_types = len(num_atoms_per_type)
         assert (
@@ -78,8 +89,13 @@ for i, line in enumerate(lines):
             for n in range(0, totalAtoms):
                 listAtomTypes.append(atomType)
 
+    elif "aborting loop because EDIFF is reached" in line:
+        electronic_convergence = True
+    elif "aborting loop EDIFF was not reached (unconverged)" in line:
+        electronic_convergence = False
+                
     # Look for lattice vectors for configuration
-    if "direct lattice vectors" in line:
+    elif "direct lattice vectors" in line:
         lattice_x = [float(x) for x in lines[i + 1].split()[0:3]]
         lattice_y = [float(y) for y in lines[i + 2].split()[0:3]]
         lattice_z = [float(z) for z in lines[i + 3].split()[0:3]]
@@ -87,7 +103,7 @@ for i, line in enumerate(lines):
 
     # Look for stresses for configuration.  Assumes total stress is 14 lines down
     # from where FORCE on cell is found
-    if "FORCE on cell" in line:
+    elif "FORCE on cell" in line:
         stress_xx, stress_yy, stress_zz, stress_xy, stress_yz, stress_zx = [
             float(s) for s in lines[i + 14].split()[2:8]
         ]
@@ -96,7 +112,7 @@ for i, line in enumerate(lines):
         stress_allz = [stress_zx, stress_yz, stress_zz]
         stress_component = [stress_allx, stress_ally, stress_allz]
     # Look for positions and forces for configuration
-    if "TOTAL-FORCE (eV/Angst)" in line:
+    elif "TOTAL-FORCE (eV/Angst)" in line:
 
         atom_cords = []
         atom_force = []
@@ -114,7 +130,7 @@ for i, line in enumerate(lines):
     # Look for total energy of configuration.  Assumes that value is four
     # lines past where FREE ENERGIE OF THE ION-ELECTRON SYSTEM is found
 
-    if "FREE ENERGIE OF THE ION-ELECTRON SYSTEM" in line:
+    elif "FREE ENERGIE OF THE ION-ELECTRON SYSTEM" in line:
         data = {}
         totalEnergy = float(lines[i + 4].split()[3])
 
@@ -129,6 +145,8 @@ for i, line in enumerate(lines):
         data["Energy"] = totalEnergy
         data["AtomTypes"] = listAtomTypes
         data["NumAtoms"] = natoms
+        data["computation_code"] = "VASP"
+        data["pseudopotential_information"] = list_POTCARS
 
         # Specify jsonfilename and put this and data into the write_json function.  All
         # json files should be output now.  The configuration number will be increased by one
@@ -136,6 +154,10 @@ for i, line in enumerate(lines):
 
         jsonfilename = JSON_file + str(outcar_config_number) + ".json"
 
-        write_json(data, jsonfilename)
+        if electronic_convergence:
+            write_json(data, jsonfilename)
+        else:
+            if write_unconverged_steps_anyway:
+                write_json(data, jsonfilename)
 
         outcar_config_number = outcar_config_number + 1


### PR DESCRIPTION
Small update to VASP2JSON.py script to skip ionic steps where the electronic structure wasn't converged - forces, total energy, and stresses aren't accurate for such steps. There's also a flag near the top you can change to get the old behavior, should you want it.
(Note, this script is just using whatever convergence criteria the VASP calculation was run at. It isn't checking the VASP convergence settings.)

Also, it now records the POTCAR files that were used in the calculation.
Also also, replaces all the "if" statements after the first with "elif"s, since they are all mutually exclusive.