### PR TITLE
fixed the rounding error in test/train split

### DIFF
--- a/fitsnap3lib/scrapers/scrape.py
+++ b/fitsnap3lib/scrapers/scrape.py
@@ -118,15 +118,15 @@ class Scraper:
             nfiles = len(folder_files)
             if training_size < 1 or (training_size == 1 and size_type == float):
                 if training_size == 1:
-                    training_size = abs(training_size) * len(folder_files)
+                    training_size = abs(training_size) * nfiles
                 elif training_size == 0:
                     pass
                 else:
-                    training_size = max(1, int(abs(training_size) * len(folder_files) - 0.5))
+                    training_size = max(1, int(abs(training_size) * nfiles + 0.5))
                 if bc_bool and testing_size == 0:
                     testing_size = nfiles - training_size
             if testing_size != 0 and (testing_size < 1 or (testing_size == 1 and testing_size_type == float)):
-                testing_size = max(1, int(abs(testing_size) * len(folder_files) - 0.5))
+                testing_size = max(1, int(abs(testing_size) * nfiles + 0.5))
             training_size = self._float_to_int(training_size)
             testing_size = self._float_to_int(testing_size)
             if nfiles-testing_size-training_size < 0:


### PR DESCRIPTION
Should stop FitSNAP from dropping a random config or two from each group.

Full disclosure, I did not thoroughly test this. Just checked the formula and one test case.