### PR TITLE
dump_a() cannot be a static method as it is accessing the shared_arrays

### DIFF
--- a/fitsnap3lib/solvers/svd.py
+++ b/fitsnap3lib/solvers/svd.py
@@ -34,8 +34,7 @@ class SVD(Solver):
             self.fit, residues, rank, s = lstsq(aw, bw, 1.0e-13)
         decorated_perform_fit()
 
-    @staticmethod
-    def _dump_a():
+    def _dump_a(self):
         np.savez_compressed('a.npz', a=self.pt.shared_arrays['a'].array)
 
     def _dump_x(self):


### PR DESCRIPTION
Just a small bug fix 