### PR TITLE
Write pickled configuration list when calculating descriptors for NNs

### DIFF
--- a/docs/paper/paper.bib
+++ b/docs/paper/paper.bib
@@ -49,11 +49,16 @@
   publisher={Nature Publishing Group}
 }
 
-@article{musaelian2022learning,
-  title={Learning Local Equivariant Representations for Large-Scale Atomistic Dynamics},
+@article{musaelian2023learning,
+  title={Learning local equivariant representations for large-scale atomistic dynamics},
   author={Musaelian, Albert and Batzner, Simon and Johansson, Anders and Sun, Lixin and Owen, Cameron J and Kornbluth, Mordechai and Kozinsky, Boris},
-  journal={arXiv preprint arXiv:2204.05249},
-  year={2022}
+  journal={Nature Communications},
+  volume={14},
+  number={1},
+  pages={579},
+  year={2023},
+  doi = {https://doi.org/10.1038/s41467-023-36329-y},
+  publisher={Nature Publishing Group UK London}
 }
 
 @article{khorshidi2016amp,

--- a/docs/source/Tests.rst
+++ b/docs/source/Tests.rst
@@ -2,9 +2,9 @@ Tests
 =====
 
 Our continuous integration (CI) tests are implemented using GitHub Actions. This 
-involve two main tests for consistency and validation:
+involves two main tests for consistency and validation:
 
-1. Consistency of linear fits. Here we check that our simple
+1. Consistency of linear fits. Here we check that our simple examples
    :code:`examples/Ta_Linear_JCP2014` produces the same fitting coefficients 
    from a previous standard in :code:`20May21_Standard`.
 

--- a/fitsnap3lib/fitsnap.py
+++ b/fitsnap3lib/fitsnap.py
@@ -142,6 +142,10 @@ class FitSnap:
             else:
                 self.solver.fit = self.fit
                 
+        # If not performing a fit, keep in mind that the `configs` list is None 
+        # for nonlinear models. Keep this in mind when performing error 
+        # analysis.
+        
         @self.pt.single_timeit
         def fit_gather():
             self.solver.fit_gather()


### PR DESCRIPTION
There is demand to write descriptors in a format ready for NN evaluation, without doing a fit. 

With linear models we use dataframes for this purpose.

For NNs, we write a pickled list of Configuration objects which can then be used by the user in library mode.

Examples will follow.