### PR TITLE
Transpose trick example, add multinode capability

### DIFF
--- a/examples/library/transpose_trick/ace-WBe.py
+++ b/examples/library/transpose_trick/ace-WBe.py
@@ -20,6 +20,7 @@ NOTE: This workflow is under development and therefore script requires changes.
 
 """
 
+from time import time
 from mpi4py import MPI
 from fitsnap3lib.fitsnap import FitSnap
 import numpy as np
@@ -113,6 +114,9 @@ comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 nprocs = comm.Get_size()
 
+if rank == 0:
+    start = time()
+
 # Create an input dictionary containing settings.
 settings = \
 {
@@ -176,7 +180,8 @@ settings = \
     "dump_descriptors": 0,
     "dump_truth": 0,
     "dump_weights": 0,
-    "dump_dataframe": 0
+    "dump_dataframe": 0,
+    "multinode_testing": 1
     },
 "GROUPS":
     {
@@ -238,14 +243,19 @@ fs.pt.all_barrier()
 comm.Allreduce([c, MPI.DOUBLE], [c_all, MPI.DOUBLE])
 comm.Allreduce([d, MPI.DOUBLE], [d_all, MPI.DOUBLE])
 
-# Perform least squares fit.
-#coeffs = least_squares(c_all,d_all)
-coeffs = ridge(c_all, d_all)
-# Now `coeffs` is owned by all procs, good for parallel error analysis.
+if rank == 0:
+    # Perform least squares fit.
+    #coeffs = least_squares(c_all,d_all)
+    coeffs = ridge(c_all, d_all)
+    # Now `coeffs` is owned by all procs, good for parallel error analysis.
 
-# Calculate errors for this instance (not required).
-# error_analysis(fitsnap)
+    # Calculate errors for this instance (not required).
+    # error_analysis(fitsnap)
 
-# Write LAMMPS files.
-# NOTE: Without error analysis, `fitsnap.solver.errors` is an empty list and will not be written to file.
-fs.output.output(coeffs, fs.solver.errors)
+    # Write LAMMPS files.
+    # NOTE: Without error analysis, `fitsnap.solver.errors` is an empty list and will not be written to file.
+    fs.output.output(coeffs, fs.solver.errors)
+
+    end = time()
+    sec = round(end-start,3)
+    print(f"Time to complete fit: {sec} s")

--- a/examples/library/transpose_trick/snap-Ta.py
+++ b/examples/library/transpose_trick/snap-Ta.py
@@ -20,6 +20,7 @@ NOTE: This workflow is under development and therefore script requires changes.
 
 """
 
+from time import time
 from mpi4py import MPI
 from fitsnap3lib.fitsnap import FitSnap
 import numpy as np
@@ -113,6 +114,11 @@ comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 nprocs = comm.Get_size()
 
+# print(f"HOST INFO: {MPI.HOST}, {rank}, {nprocs}\n")
+
+if rank == 0:
+    start = time()
+
 # Create an input dictionary containing settings.
 settings = \
 {
@@ -174,7 +180,8 @@ settings = \
     "dump_descriptors": 1,
     "dump_truth": 1,
     "dump_weights": 1,
-    "dump_dataframe": 1
+    "dump_dataframe": 1,
+    "multinode_testing": 1
     },
 "GROUPS":
     {
@@ -255,3 +262,7 @@ if rank == 0:
     # Write LAMMPS files.
     # NOTE: Without error analysis, `fitsnap.solver.errors` is an empty list and will not be written to file.
     fitsnap.output.output(coeffs, fitsnap.solver.errors)
+
+    end = time()
+    sec = round(end-start,3)
+    print(f"Time to complete fit: {sec} s", )

--- a/examples/library/transpose_trick/snap-WBe.py
+++ b/examples/library/transpose_trick/snap-WBe.py
@@ -20,6 +20,7 @@ NOTE: This workflow is under development and therefore script requires changes.
 
 """
 
+from time import time
 from mpi4py import MPI
 from fitsnap3lib.fitsnap import FitSnap
 import numpy as np
@@ -113,6 +114,10 @@ comm = MPI.COMM_WORLD
 rank = comm.Get_rank()
 nprocs = comm.Get_size()
 
+if rank == 0:
+    start = time()
+
+
 # Create an input dictionary containing settings.
 settings = \
 {
@@ -177,7 +182,8 @@ settings = \
     "dump_descriptors": 0,
     "dump_truth": 0,
     "dump_weights": 0,
-    "dump_dataframe": 0
+    "dump_dataframe": 0,
+    "multinode_testing": 1
     },
 "GROUPS":
     {
@@ -259,3 +265,8 @@ if rank == 0:
     # Write LAMMPS files.
     # NOTE: Without error analysis, `fitsnap.solver.errors` is an empty list and will not be written to file.
     fs.output.output(coeffs, fs.solver.errors)
+
+    end = time()
+    sec = round(end-start,3)
+    print(f"Time to complete fit: {sec} s")
+

--- a/fitsnap3lib/fitsnap.py
+++ b/fitsnap3lib/fitsnap.py
@@ -92,6 +92,9 @@ class FitSnap:
         if (hasattr(self.pt, "lammps_version")):
             if (self.config.sections['CALCULATOR'].nonlinear and (self.pt.lammps_version < 20220915) ):
                 raise Exception(f"Please upgrade LAMMPS to 2022-09-15 or later to use nonlinear solvers.")
+        
+        if (self.pt._number_of_nodes > 1 and self.config.sections["EXTRAS"].multinode_testing:
+            raise Exception(f"WARNING: multinode testing toggled on!\nWARNING: this feature is currently only useful for the 'transpose_trick' example.\nWARNING: Otherwise, must use ScaLAPACK solver when using > 1 node or you'll fit to 1/nodes of data.\nWARNING: use 'multinode_testing' at your own risk.")
 
         if (self.pt._number_of_nodes > 1 and not self.config.sections["SOLVER"].true_multinode) and not self.config.sections["EXTRAS"].multinode_testing:
             raise Exception(f"Must use ScaLAPACK solver when using > 1 node or you'll fit to 1/nodes of data.")

--- a/fitsnap3lib/fitsnap.py
+++ b/fitsnap3lib/fitsnap.py
@@ -93,8 +93,8 @@ class FitSnap:
             if (self.config.sections['CALCULATOR'].nonlinear and (self.pt.lammps_version < 20220915) ):
                 raise Exception(f"Please upgrade LAMMPS to 2022-09-15 or later to use nonlinear solvers.")
         
-        if (self.pt._number_of_nodes > 1 and self.config.sections["EXTRAS"].multinode_testing:
-            raise Exception(f"WARNING: multinode testing toggled on!\nWARNING: this feature is currently only useful for the 'transpose_trick' example.\nWARNING: Otherwise, must use ScaLAPACK solver when using > 1 node or you'll fit to 1/nodes of data.\nWARNING: use 'multinode_testing' at your own risk.")
+        if (self.pt._number_of_nodes > 1 and self.config.sections["EXTRAS"].multinode_testing):
+            self.pt.single_print(f"WARNING: multinode testing toggled on!\nWARNING: this feature is currently only useful for the 'transpose_trick' example.\nWARNING: Otherwise, must use ScaLAPACK solver when using > 1 node or you'll fit to 1/nodes of data.\nWARNING: use 'multinode_testing' at your own risk.\n")
 
         if (self.pt._number_of_nodes > 1 and not self.config.sections["SOLVER"].true_multinode) and not self.config.sections["EXTRAS"].multinode_testing:
             raise Exception(f"Must use ScaLAPACK solver when using > 1 node or you'll fit to 1/nodes of data.")

--- a/fitsnap3lib/fitsnap.py
+++ b/fitsnap3lib/fitsnap.py
@@ -93,7 +93,7 @@ class FitSnap:
             if (self.config.sections['CALCULATOR'].nonlinear and (self.pt.lammps_version < 20220915) ):
                 raise Exception(f"Please upgrade LAMMPS to 2022-09-15 or later to use nonlinear solvers.")
 
-        if (self.pt._number_of_nodes > 1 and not self.config.sections["SOLVER"].true_multinode):
+        if (self.pt._number_of_nodes > 1 and not self.config.sections["SOLVER"].true_multinode) and not self.config.sections["EXTRAS"].multinode_testing:
             raise Exception(f"Must use ScaLAPACK solver when using > 1 node or you'll fit to 1/nodes of data.")
     
     def __del__(self):


### PR DESCRIPTION
The transpose trick example is included as an example of how to break down the A matrix into smaller parts, saving on memory and allowing different kinds of parallelization of fitting processes.
However, as currently implemented, it can only be performed on a single node due to a node check in `fitsnap.py`.
The node check is important to avoid fitting slowdowns when not using the ScaLAPACK solver, but also prevents us from using the transpose trick to its fullest potential.

This PR adds a simple check of the `multinode_testing` variable from the [EXTRAS] section into the ScaLAPACK node check.
If `multinode_testing` is set to 0 or not included, the node check will be performed as usual, and exit if > 1 node detected.
If `multinode_testing` is set to 1 and >1 node detected, a warning will be printed.

The four transpose_trick example files have also been updated with `multinode_testing` toggled on. 