### PR TITLE
Parallel genetic algorithm (with some other stuff)

### DIFF
--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -101,7 +101,7 @@ class HyperparameterStruct:
         print ("HH varrange dict: ",variable_ranges_dicti)
         lhsamples = latin_hypercube_sample(variable_ranges_dicti, variable_types_dict, num_samples)
         return lhsamples
-    
+
 
 # tournament selection
 def tournament_selection(population, scores, k=3, inputseed=None):
@@ -114,7 +114,6 @@ def tournament_selection(population, scores, k=3, inputseed=None):
             selection_ix = ix
     return population[selection_ix]
 
-
 class Selector:
     def __init__(self,selection_style = 'tournament'):
         self.selection_style = selection_style
@@ -125,7 +124,7 @@ class Selector:
             self.selection = tournament_selection
 
 
-def crossover(p1, p2, ne, w_combo_delta=np.array([]), ef_rat_delta=np.array([]), inputseed=None):
+def crossover(p1, p2, ne, w_combo_delta=np.array([]), ef_rat_delta=np.array([]), es_rat_delta=np.array([]), inputseed=None):
     """
     Genetic operator function that takes two existing population members ('creatures') and recombines them to create two new ones for the next generation. Or in the immortal words of the Goff... "when 2 parent creatures love eachother very much, they make/adopt 2 children creatures"
     
@@ -144,30 +143,36 @@ def crossover(p1, p2, ne, w_combo_delta=np.array([]), ef_rat_delta=np.array([]),
     if inputseed != None:
         np.random.seed(inputseed)
     c1, c2 = p1.copy(), p2.copy()
-    c1e,c1f = tuple(c1.reshape(2,ne))
-    c2e,c2f = tuple(c2.reshape(2,ne))
-    p1e,p1f = tuple(p1.reshape(2,ne))
-    p2e,p2f = tuple(p2.reshape(2,ne))
+    c1e,c1f,c1s = tuple(c1.reshape(3,ne))
+    c2e,c2f,c2s = tuple(c2.reshape(3,ne))
+    p1e,p1f,p1s = tuple(p1.reshape(3,ne))
+    p2e,p2f,p2s = tuple(p2.reshape(3,ne))
 
     # select crossover point that corresponds to a certain group
+    # NOTE meg changed var name 'pt' to 'cpt' to avoid confusion with parallel tools "pt" later
+    ##LOGAN QUESTION: Can you confirm these indices are correct?
     cpt = np.random.randint(1, ne-2)
     # only perform crossover between like hyperparameters (energy and energy then force and force, etc.)
     if np.shape(w_combo_delta)[0] != 0:
         c1e = np.append(p1e[:cpt], p2e[cpt:])*w_combo_delta
         c1f = np.append(p1f[:cpt], p2f[cpt:])*ef_rat_delta
+        c1s = np.append(p1s[:cpt], p2s[cpt:])*es_rat_delta
         c2e = np.append(p2e[:cpt], p1e[cpt:])*w_combo_delta
         c2f = np.append(p2f[:cpt], p1f[cpt:])*ef_rat_delta
+        c2s = np.append(p2s[:cpt], p1s[cpt:])*es_rat_delta
     else:
-        c1e = np.append(p1e[:cpt], p2e[cpt:])
-        c1f = np.append(p1f[:cpt], p2f[cpt:])
-        c2e = np.append(p2e[:cpt], p1e[cpt:])
-        c2f = np.append(p2f[:cpt], p1f[cpt:])
-    c1 = np.append(c1e,c1f)
-    c2 = np.append(c2e,c2f)
+        c1e = np.append(p1e[:cpt] , p2e[cpt:])
+        c1f = np.append(p1f[:cpt] , p2f[cpt:])
+        c1s = np.append(p1s[:cpt] , p2s[cpt:])
+        c2e = np.append(p2e[:cpt] , p1e[cpt:])
+        c2f = np.append(p2f[:cpt] , p1f[cpt:])
+        c2s = np.append(p2s[:cpt] , p1s[cpt:])
+    c1 = np.concatenate((c1e,c1f,c1s))
+    c2 = np.concatenate((c2e,c2f,c2s))
     return [c1, c2]
 
 
-def update_weights(fs, test_w_combo, test_ef_rat, gtks, size_b, grouptype, test_virial_w=(1.e-8,)):
+def update_weights(fs, test_w_combo, test_ef_rat, test_es_rat, gtks, size_b, grouptype, initial_weights=False):
     """
     Updates creature weights 
     
@@ -184,11 +189,22 @@ def update_weights(fs, test_w_combo, test_ef_rat, gtks, size_b, grouptype, test_
         (none, updates FitSNAP instance in-place)
     """
     if len(test_virial_w) == 1:
-        tstwdct = {gkey:{'eweight':test_w_combo[ig], 'fweight':test_w_combo[ig]*test_ef_rat[ig], 'vweight':test_virial_w[0]} for ig,gkey in enumerate(gtks)  }
-    elif len(test_virial_w) == len(test_ef_rat):
-        tstwdct = {gkey:{'eweight':test_w_combo[ig], 'fweight':test_w_combo[ig]*test_ef_rat[ig], 'vweight':test_virial_w[ig]} for ig,gkey in enumerate(gtks)  }
+    if initial_weights:
+        if len(test_es_rat) == 1:
+            tstwdct = {gkey:{'eweight':initial_weights[gkey][0]*test_w_combo[ig], 'fweight':initial_weights[gkey][1]*test_w_combo[ig]*test_ef_rat[ig], \
+                             'vweight':initial_weights[gkey][2]*test_w_combo[ig]*test_es_rat[0]} for ig,gkey in enumerate(gtks)  }
+        elif len(test_es_rat) == len(test_ef_rat):
+            tstwdct = {gkey:{'eweight':initial_weights[gkey][0]*test_w_combo[ig], 'fweight':initial_weights[gkey][1]*test_w_combo[ig]*test_ef_rat[ig], \
+                             'vweight':initial_weights[gkey][2]*test_w_combo[ig]*test_es_rat[ig]} for ig,gkey in enumerate(gtks)  }
+        else:
+            raise IndexError("not enough virial indices per energy and force indices")
     else:
-        raise IndexError("not enough virial indices per energy and force indices")
+        if len(test_es_rat) == 1:
+            tstwdct = {gkey:{'eweight':test_w_combo[ig], 'fweight':test_w_combo[ig]*test_ef_rat[ig], 'vweight':test_w_combo[ig]*test_es_rat[0]} for ig,gkey in enumerate(gtks)  }
+        elif len(test_es_rat) == len(test_ef_rat):
+            tstwdct = {gkey:{'eweight':test_w_combo[ig], 'fweight':test_w_combo[ig]*test_ef_rat[ig], 'vweight':test_w_combo[ig]*test_es_rat[ig]} for ig,gkey in enumerate(gtks)  }
+        else:
+            raise IndexError("not enough virial indices per energy and force indices")
 
     #loop through data and update pt shared array based on group type
     for index_b in range(size_b):
@@ -199,6 +215,7 @@ def update_weights(fs, test_w_combo, test_ef_rat, gtks, size_b, grouptype, test_
             fs.pt.shared_arrays['w'].array[index_b] = tstwdct[gkey]['fweight']
         elif fs.pt.fitsnap_dict['Row_Type'][index_b] == 'Stress':
             fs.pt.shared_arrays['w'].array[index_b] = tstwdct[gkey]['vweight']
+
 
 
 def ediff_cost(fs, fit, g1, g2, target, grouptype, rowtype):
@@ -239,8 +256,10 @@ def ediff_cost(fs, fit, g1, g2, target, grouptype, rowtype):
 
     return np.abs(diff - target)
 
-
-def fit_and_cost(fs, costweights):
+#NOTE fit_and_cost will likely need to be modified to print current fit if
+# other objective functions are to be added. 
+# @fs.pt.rank_zero
+def fit_and_cost(fs,costweights):
     """
     TODO fill in description
 
@@ -254,21 +273,21 @@ def fit_and_cost(fs, costweights):
     
     Objective function note: fit_and_cost will likely need to be modified to print current fit if other objective functions are to be added. See commented-out examples below.
     """
-    etot_weight, ftot_weight = tuple(costweights)
+    etot_weight, ftot_weight, stot_weight = tuple(costweights)
     #clear old fit and solve test fit
     fs.solver.fit = None
     fs.perform_fit()
     fittst = fs.solver.fit
     errstst = fs.solver.errors
     rmse_tst = errstst.iloc[:,2].to_numpy()
-    rmse_countstst = errstst.iloc[:,0].to_numpy()
+    #rmse_countstst = errstst.iloc[:,0].to_numpy()  ##LOGAN NOTE: unused, can just remove unless here for instructive purposes
 
     #fs.pt.single_print(errstst)
-    rmse_eattst = rmse_tst[0]
-    rmse_fattst = rmse_tst[1]
+    rmse_eattst, rmse_fattst, rmse_sattst = rmse_tst[0:3]
     CO = CostObject()
     CO.add_contribution(rmse_eattst,etot_weight)
     CO.add_contribution(rmse_fattst,ftot_weight)
+    CO.add_contribution(rmse_sattst,stot_weight)
     # commented examples on how to use energy differences in the objective function
     # a SINGLE structure is added to two new fitsnap groups, the corresponding energy
     # difference between group 1 and group 2 is given as the target (in eV) (NOT eV/atom)
@@ -314,7 +333,7 @@ def seed_maker(fs, mc,mmax = 1000000000,use_saved_seeds=True):
     return seeds
 
 
-def mutation(current_w_combo,current_ef_rat,my_w_ranges,my_ef_ratios,ng,w_combo_delta=np.array([]),ef_rat_delta=np.array([]),apply_random=True,full_mutation=False):
+def mutation(current_w_combo, current_ef_rat, current_es_rat, my_w_ranges,my_ef_ratios, my_es_ratios,ng, w_combo_delta=np.array([]), ef_rat_delta=np.array([]), s_combo_delta=np.array([]), apply_random=True, full_mutation=False):
     """
     Genetic operator function that ... TODO finish after learning
     
@@ -338,47 +357,62 @@ def mutation(current_w_combo,current_ef_rat,my_w_ranges,my_ef_ratios,ng,w_combo_
         current_w_combo = np.array(current_w_combo)
     if type(current_ef_rat) == tuple:
         current_ef_rat = np.array(current_ef_rat)
+    if type(current_es_rat) == tuple:
+        current_es_rat = np.array(current_es_rat)
     if full_mutation:
         if apply_random:
             test_w_combo = np.random.rand()*np.random.choice(my_w_ranges,ng)
             test_ef_rat = np.random.rand()*np.random.choice(my_ef_ratios,ng)
+            test_es_rat = np.random.rand()*np.random.choice(my_es_ratios,ng)
         else:
             test_w_combo = np.random.choice(my_w_ranges,ng)
             test_ef_rat = np.random.choice(my_ef_ratios,ng)
+            test_es_rat = np.random.choice(my_es_ratios,ng)
     else:
         test_w_combo = current_w_combo.copy()
         test_ef_rat = current_ef_rat.copy()
+        test_es_rat = current_es_rat.copy()
         test_w_ind = np.random.choice(range(ng))
         if apply_random:
             plusvsprd =  1 #TODO implement addition/product steps after constraining min/max weights
             if plusvsprd:
                 test_w_combo[test_w_ind] = np.random.rand() * np.random.choice(my_w_ranges)
                 test_ef_rat[test_w_ind] = np.random.rand() * np.random.choice(my_ef_ratios)
+                test_es_rat[test_w_ind] = np.random.rand() * np.random.choice(my_es_ratios)
             else:
                 test_w_combo[test_w_ind] *= np.random.rand() * np.random.choice(my_w_ranges)
                 test_ef_rat[test_w_ind] *= np.random.rand() * np.random.choice(my_ef_ratios)
-
+                test_es_rat[test_w_ind] *= np.random.rand() * np.random.choice(my_es_ratios)
         else:
             test_w_combo[test_w_ind] = np.random.choice(my_w_ranges)
             test_ef_rat[test_w_ind] = np.random.choice(my_ef_ratios)
+            test_es_rat[test_w_ind] = np.random.choice(my_es_ratios)
     if np.shape(w_combo_delta)[0] != 0:
-        return test_w_combo * w_combo_delta, test_ef_rat*ef_rat_delta
+        return test_w_combo * w_combo_delta, test_ef_rat*ef_rat_delta, test_es_rat*s_combo_delta
     else:
-        return test_w_combo,test_ef_rat
+        return test_w_combo,test_ef_rat,test_es_rat
 
 
 def print_final(fs, gtks, ew_frcrat_final, write_to_json=False):
-    ew_final,frcrat_final = ew_frcrat_final
+    ew_final, frcrat_final, srcrat_final = ew_frcrat_final
 
-    # fitsnap TODO: to accurately output the best weights, we also need the train/test split specified by the user. at least when using the JSON scraper, training_size and_testing size are converted from floats into integers, which is inconsistent and should be updated. to work around that for now, we take the testing_size and training_size integers and convert them back into fractions. these will probably be very similar to the user's input, but may vary a little bit.
+    calc_stress = fs.config.sections["CALCULATOR"].stress
+    print_stress = True
+    wcols = [v for v in fs.config.sections["GROUPS"].group_sections if "weight" in v]
+    num_wcols = len(wcols)
+    if num_wcols == 2:
+        print_stress = False
+        
+    # fitsnap TODO: to accurately output the best weights, we also need the train/test split specified by the user. at least when using the JSON scraper, training_size and_testing size are converted from floats into integers, which is inconsistent and should be updated. to work around that for now, we take the testing_size and training_size integers and convert them back into fractions. these will probably be very similar to the user's input, but may vary a little bit
     loc_gt = fs.config.sections["GROUPS"].group_table
 
     collect_lines = []
     fs.pt.single_print('\n--> Best group weights:')
     for idi, dat in enumerate(gtks):
-
         en_weight = ew_final[idi]
         frc_weight = ew_final[idi]*frcrat_final[idi]
+        if print_stress:
+            src_weight = ew_final[idi]*srcrat_final[idi]
 
         ntrain = loc_gt[dat]['training_size']
         ntest = loc_gt[dat]['testing_size']
@@ -386,19 +420,15 @@ def print_final(fs, gtks, ew_frcrat_final, write_to_json=False):
         train_sz = round(ntrain/ntot,2)
         test_sz = round(ntest/ntot,2)
 
-        # TODO continue implementing stress weights, or at least whatever user has in input file
-        # stress weight is currently excluded automatically because code crashes if fitting to stresses
-        # in the future, we can still print whatever user has for group_variables (even if not fit to)
-        str_weight = ''
-
         # fs.pt.single_print('%s       =  %1.2f      %1.2f      %.16E      %.16E      1.E-12' % (dat, train_sz,test_sz,en_weight,frc_weight))
         group_line = f'{dat}       =  {train_sz}      {test_sz}      {en_weight}      {frc_weight}'
-        if str_weight != "":
-            group_line += f"      {str_weight}"
+        if print_stress:
+            group_line += f"      {src_weight}"
         fs.pt.single_print(group_line)
         collect_lines.append([dat, group_line.replace(f'{dat}       =  ','')])
     fs.pt.single_print("")
 
+    # MEG NOTE: this write_to_json works fine but is a bit of a mess
     if write_to_json:
         infile_name = fs.config.infile
         settings = fs.config.indict
@@ -442,7 +472,8 @@ def print_final(fs, gtks, ew_frcrat_final, write_to_json=False):
         with open(outfile, 'w') as f:
             json.dump(settings, f, indent=4)
 
-
+#LOGAN NOTE: HAVE NOT UPDATED THIS FUNCTION - DON'T THINK IT NEEDS IT?
+# MEG NOTE: i think you're correct but let's have James take a look
 def latin_hypercube_sample(variable_ranges_dict, variable_types_dict, num_samples, seed=12345):
     # TODO is this doubled from lhparams, should be removed?
     # TODO if not, should this be varied or taken from lhparams?
@@ -509,219 +540,41 @@ def prep_fitsnap_input(fs, smartweights_override=False):
     # for now, elegantly crash if user has 3 or fewer groups 
     num_groups = len(fs.config.sections["GROUPS"].group_table.keys())
     if num_groups <= 3:
+        fs.pt.single_print("\n")
         fs.pt.single_print("\n!ERROR: Need 4 or more groups to use genetic algorithm (see comment)!")
-        fs.pt.single_print("!ERROR: I am elegantly crashing now so that you can contact the FitSNAP team to have them solve this for you!!\n")
+        fs.single_print("!ERROR: I am elegantly crashing now so that you can contact the FitSNAP team to have them solve this for you!!")
+        fs.pt.single_print("\n")
         exit()
 
-    # turn off fitting to stresses 
-    # TODO get rid of this when fitting to stresses implemented
+    # turn off fitting to stresses
+    # LOGAN NOTE: TODO: HANDLE NO STRESS FITTING WITH SMART REMOVAL OF STRESS VARIABLES IN THIS CODE 
+    # MEG NOTE: we could put the removal here, but i think it makes more sense within the GA itself using the fs.config object settings. 
+    # this function serves to 1) check and make minor changes to the FitSNAP config, and 2) warn the user about that. 
+    # maybe we need to TODO factor out this function and just put those warnings right where things are changed? 
+    # or is it better to warn before the initial fit, to give the panicked user enough time to hit CTRL+C a billion times before it starts rolling?
     calc_stress = fs.config.sections["CALCULATOR"].stress
-    if calc_stress == 1:
-        fs.pt.single_print(f"\n!ERROR: Current version of optimizer does not support fitting to stresses!")
-        fs.pt.single_print(f"!ERROR: Please set [CALCULATOR] stress = 0 and remove 'vweight' columns in [GROUPS], then run script again.")
-        fs.pt.single_print(f"!ERROR: If this elegant crash stresses (!) you out, please contact the FitSNAP team to get this feature implemented!\n")
-        fs.pt.all_barrier()
+    has_vweights = True if "vweight" in fs.config.sections["GROUPS"].group_sections else False
+    if not calc_stress and has_vweights:
+        fs.pt.single_print("\n")
+        fs.pt.single_print(f"!WARNING: Your FitSNAP input script indicates you don't want to fit to stresses ([CALCULATOR] stress = 0), but your [GROUPS] have a 'vweights' column!")
+        fs.pt.single_print(f"!WARNING: Since you don't want to fit to stresses, we're gonna populate all vweights columns with 0!")
+        fs.pt.single_print(f"!WARNING: We're just warning you here because the output might be confusing.")
+        fs.pt.single_print(f"!WARNING: <---- consider yourself warned!")
+        fs.pt.single_print("\n")
+    if calc_stress and not has_vweights:
+        fs.pt.single_print("\n")
+        fs.pt.single_print(f"!ERROR: Your FitSNAP input script indicates you want to fit to stresses ([CALCULATOR] stress = 1), but your [GROUPS] section is MISSING the 'vweights' column!")
+        fs.pt.single_print(f"!ERROR: To fix this, add the word 'vweights' to the end of the [GROUPS] group_section variable, 'float' to the end of the [GROUPS] group_types variable, and some number (doesn't matter what) to the end of each of your group's weights.")
+        fs.pt.single_print(f"!ERROR: Try again after adding that stuff! Now exiting.")
+        fs.pt.single_print("\n")
         exit()
 
-        # TODO commented-out code below could work, but getting an error in parallel_tools.
-        # fs.pt.single_print(f"WARNING: Current version of optimizer does not support fitting to stresses!")
-        # fs.pt.single_print(f"WARNING: Turning off fitting to stresses, and no vweights will be printed.")
-        # fs.config.sections["CALCULATOR"].stress = 0
-        # for key, val in fs.config.sections["GROUPS"].group_table.items():
-            # if 'vweight' in val.keys():
-                # del val['vweight']
-                # fs.config.sections["GROUPS"].group_table[key] = val
-
-
 #-----------------------------------------------------------------------
-# begin the primary optimization functions
+# begin the primary optimzation functions
 #-----------------------------------------------------------------------
-def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e-4,1.e-3,1.e-2,1.e-1,1,1.e1,1.e2,1.e3,1.e4], my_ef_ratios=[0.001,0.01,0.1,1,10,100,1000], etot_weight=1.0, ftot_weight=1.0, r_cross=0.9, r_mut=0.1, conv_thr = 1.E-10, conv_check = 2., force_delta_keywords=[], write_to_json=False, opt_stress=False, ):
-    """
-    Begin in-function optimization hyperparameters
-    Note that all GA variables are initialized with defaults
 
-    Args:
-        fs: instance of FitSNAP class
-        population_size: number of candidates ("creatures") generated within one generation and tested for fitness. in this code, fitness is how well group weights perform in a FitSnap fit (no puns intended)
-        ngenerations: maximum number of allowed iterations of populations. this ends the genetic algorithm calculations if the convergence threshold (conv_thr, see below) is not reached beforehand
-        my_w_ranges: allowed scaling factors for energy weights
-        my_ef_ratios: allowed scaling factors for force weights
-        etot_weight and ftot_weight: weights for energy and force rmse in the optimizer cost function
-        r_cross and r_mut: cross over (parenting) and mutation hyperparameters
-        conv_thr: convergence threshold for full function (value of RMSE E + RMSE F at which simulation is terminated" 
-        conv_check: fraction of ngenerations to start checking for convergence (convergence checks wont be performed very early)
-    
-    Returns:
-        (nothing, updates FitSNAP instance in-place)
-    """
-    time1 = time.time()
-
-    # population of generations
-    # both moved to function args
-    # population can't have odd numbers currently
-    if population_size % 2 == 1:
-      fs.pt.single_print(f"WARNING: Cannot use odd numbers for population size (input: {population_size})")
-      fs.pt.single_print(f"WARNING: Updating population_size: population_size +=1 (larger populations seem to perform better, in Dakota at least)")
-      population_size += 1
-
-    # get groups and weights 
-    gtks = fs.config.sections["GROUPS"].group_table.keys()
-    gtks = list(gtks)
-    fs.pt.single_print('groups',gtks)
-
-    size_b = np.shape(fs.pt.fitsnap_dict['Row_Type'])[0]
-    grouptype = fs.pt.fitsnap_dict['Groups'].copy()
-    rowtype = fs.pt.fitsnap_dict['Row_Type'].copy()
-
-    countmaxtot = int(population_size*(ngenerations+2))
-    seedsi = seed_maker(fs, countmaxtot)
-
-    #number of hyperparameters:
-    # num of energy group weights
-    ne = len(gtks)
-    # num of force group weights
-    nf = ne
-    ns = ne
-    # total
-    if not opt_stress:
-        nh = ne + nf
-    else:
-        nh = ne + nf + ns
-
-    # update ranges and ratios
-    eranges = [my_w_ranges]
-    ffactors = [my_ef_ratios]
-
-    # selection method (only tournament is currently implemented)
-    # TODO implement other methods?
-    selection_method = 'tournament'
-
-    # modify convergence check for new conv_flag
-    check_gen = int((ngenerations/conv_check))
-
-    # End optimization hyperparameters
-    #---------------------------------------------------------------------------
-
-    # set up generation 0
-    best_eval = 9999999.9999
-    conv_flag = False
-    first_seeds = seedsi[:population_size+1]
-    hp = HyperparameterStruct(ne,nf,eranges,ffactors)
-
-    # population = [hp.random_params(inputseed=first_seeds[ip]) for ip in range(population_size)] # TODO orig
-
-    # Random initial population for first generation:
-    #population = [hp.random_params(inputseed=first_seeds[ip]) for ip in range(population_size)]
-    # Latin hypercube population for first generation:
-    population = hp.lhs_params(num_samples=population_size,inputseed=first_seeds[0])
-
-    generation = 0
-
-    best_evals = [best_eval]
-    best = tuple(population[0])
-    sim_seeds = seedsi[population_size:]
-    np.random.seed(sim_seeds[generation])
-    w_combo_delta = np.ones(len(gtks))
-
-    # delta function to zero out force weights on structures without forces  
-    # now implemented with user-specified keywords
-    if force_delta_keywords != []:
-        not_in_fdkws = lambda gti: all([True if fdkw not in gti else False for fdkw in force_delta_keywords])
-        ef_rat_delta = np.array([1.0 if not_in_fdkws(gti) else 0.0 for gti in gtks])
-    else:
-        ef_rat_delta = np.array([1.0]*len(gtks))
-        
-    while generation <= ngenerations and best_eval > conv_thr and not conv_flag:
-        scores = []
-
-        # NOTE this is where split comm will go
-        #
-        # current generation
-        for creature in population:
-            creature_ew, creature_ffac = tuple(creature.reshape(2,ne).tolist())
-            creature_ew = tuple(creature_ew)
-            creature_ffac = tuple(creature_ffac)
-            update_weights(fs, creature_ew, creature_ffac, gtks, size_b, grouptype)
-            costi = fit_and_cost(fs,[etot_weight,ftot_weight])
-            scores.append(costi)
-
-            #NOTE to add another contribution to the cost function , you need to evaluate it in the loop
-            # and add it to the fit_and_cost function
-            # if this involves a lammps simulation, you will have to print potentials at the different steps
-            # to run the lammps/pylammps simulation. To do so, the fitsnap output file name prefix should
-            # be updated per step, then fs.write_output() should be called per step. This will likely increase
-            # the optimization time.
-        
-        # Perform MPI AllReduce here after parallel creature calculations
-        scores = 
-
-        # Anything printed with fs.pt.single_print will be included in output file.
-        fs.pt.single_print('generation, scores, popsize:',generation,len(scores),population_size)
-
-        # Print generation and best fit.
-        # bestfit = min(scores)
-        # print(f"{generation} {bestfit}")
-        for i in range(population_size):
-            if scores[i] < best_eval:
-                best, best_eval = tuple(population[i]), scores[i]
-        best_evals.append(best_eval)
-        try:
-            ## Original flag
-            conv_flag = np.round(np.var(best_evals[int(ngenerations/conv_check)-int(ngenerations/10):]),14) == 0
-            ## New flag, currently testing
-            # conv_flag = np.round(np.var(best_evals[-(check_gen*math.floor(len(best_evals)/check_gen)):]),14) == 0
-        except IndexError:
-            conv_flag = False
-        printbest = tuple([tuple(ijk) for ijk in np.array(best).reshape(2,ne).tolist()])
-        fs.pt.single_print('generation:',generation, 'score:', scores[i])
-
-        # TODO input user's settings or warn user that it will be overwritten (train_sz, test_sz)
-        print_final(fs, gtks, printbest)
-        slct = Selector(selection_style = selection_method)
-        selected = [slct.selection(population, scores) for creature_idx in range(population_size)]
-        del slct
-
-        # new generation
-        children = list()
-        for ii in range(0, population_size, 2):
-            # get selected parents in pairs
-            p1, p2 = selected[ii], selected[ii+1]
-            # crossover and mutation
-            rndcross, rndmut = tuple(np.random.rand(2).tolist())
-            if rndcross <= r_cross:
-                cs = crossover(p1,p2,len(gtks),w_combo_delta,ef_rat_delta)
-            else:
-                cs = [p1,p2]
-            for c in cs:
-                # mutation
-                if rndmut <= r_mut:
-                    current_creature_ew, current_creature_ffac = tuple(c.reshape(2,ne))
-                    current_creature_ew = tuple(current_creature_ew)
-                    current_creature_ffac = tuple(current_creature_ffac)
-
-                    mutated_creature_ew, mutated_creature_ffac = mutation(current_creature_ew,current_creature_ffac,my_w_ranges,my_ef_ratios,ng=len(gtks),w_combo_delta=w_combo_delta,ef_rat_delta=ef_rat_delta, apply_random=True,full_mutation=False)
-
-                    c = np.append(mutated_creature_ew,mutated_creature_ffac)
-                    # store for next generation
-                children.append(c)
-        generation += 1
-        np.random.seed(sim_seeds[generation])
-        population = children
-    best_ew, best_ffac = tuple(np.array(best).reshape(2,ne).tolist())
-    best_ew = tuple(creature_ew)
-    best_ffac = tuple(creature_ffac)
-    update_weights(fs, best_ew, best_ffac, gtks, size_b, grouptype)
-    costi = fit_and_cost(fs,[etot_weight,ftot_weight])
-    print_final(fs, gtks, tuple([best_ew,best_ffac]), write_to_json=write_to_json)
-    time2 = time.time()
-    elapsed = round(time2 - time1, 2)
-    fs.pt.single_print(f'Total optimization time: {elapsed} s')
-    fs.pt.single_print('Writing final output')
-    fs.write_output()
-
-
-def sim_anneal(fs):
+# @fs.pt.rank_zero
+def sim_anneal(fs):  ##LOGAN NOTE: I have not yet updated this function
     #---------------------------------------------------------------------------
     # Begin optimization hyperparameters
     time1 = time.time()
@@ -729,8 +582,22 @@ def sim_anneal(fs):
     # get groups and weights 
     gtks = fs.config.sections["GROUPS"].group_table.keys()
     gtks = list(gtks)
-    fs.pt.single_print('groups',gtks)
+    fs.pt.single_print('Groups:', gtks)
+    fs.pt.single_print('\n')
 
+    # check if fitting to stresses turned on
+    # if not, then set all stress weights to zero by populating stress_delta_keywords with all group names
+    # a warning about this behavior is included in this module's "prep_fitnsap_input" function
+    calc_stress = fs.config.sections["CALCULATOR"].stress
+    if calc_stress:
+        fs.pt.single_print("Stress fitting not yet implemented for simulated anneal!")
+        fs.pt.all_barrier()
+        return 0
+    #for future implementation
+    #if not calc_stress:
+        #stress_delta_keywords = gtks
+
+    
     size_b = np.shape(fs.pt.fitsnap_dict['Row_Type'])[0]
     grouptype = fs.pt.fitsnap_dict['Groups'].copy()
     rowtype = fs.pt.fitsnap_dict['Row_Type'].copy()
@@ -807,3 +674,218 @@ def sim_anneal(fs):
     fs.pt.single_print('Total optimization time,', time2 - time1, 'total number of fits', tot_count)
     fs.write_output()
 
+
+# @fs.pt.rank_zero
+def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e-4,1.e-3,1.e-2,1.e-1,1,1.e1,1.e2,1.e3,1.e4], my_ef_ratios=[0.001,0.01,0.1,1,10,100,1000], etot_weight=1.0, ftot_weight=1.0, stot_weight=1.0, r_cross=0.9, r_mut=0.1, conv_thr = 1.E-10, conv_check = 2., force_delta_keywords=[], stress_delta_keywords=[], write_to_json=False, my_es_ratios=[], use_initial_weights_flag=False ):
+    #---------------------------------------------------------------------------
+    # Begin in-function optimization hyperparameters
+    # snap: FitSnap instance being handled by genetic algorithm
+    # population_size: number of candidates ("creatures") generated within one generation and tested for fitness. in this code, fitness is how well group weights perform in a FitSnap fit (no puns intended)
+    # ngenerations: maximum number of allowed iterations of populations. this ends the genetic algorithm calculations if the convergence threshold (conv_thr, see below) is not reached beforehand
+    # my_w_ranges: allowed scaling factors for energy weights
+    # my_ef_ratios: allowed scaling factors for force weights
+    # etot_weight and ftot_weight: weights for energy and force rmse in the optimizer cost function
+    # r_cross and r_mut: cross over (parenting) and mutation hyperparameters
+    # conv_thr: convergence threshold for full function (value of RMSE E + RMSE F at which simulation is terminated" 
+    # conv_check: fraction of ngenerations to start checking for convergence (convergence checks wont be performed very early)
+    time1 = time.time()
+
+    # get all group names  
+    gtks = fs.config.sections["GROUPS"].group_table.keys()
+    gtks = list(gtks)
+    fs.pt.single_print('Groups:', gtks)
+    fs.pt.single_print('\n')
+
+    # check if fitting to stresses turned on
+    # if not, then set all stress weights to zero by populating stress_delta_keywords with all group names
+    # a warning about this behavior is included in this module's "prep_fitnsap_input" function
+    calc_stress = fs.config.sections["CALCULATOR"].stress
+    if not calc_stress:
+        stress_delta_keywords = gtks
+    
+    # all calculations must include 'vweights' column for internal calculations
+    # MEG NOTE: we could refactor all internal GA inputs into arrays with 2 or 3 cols to get around this, but that's a bigger overhaul and not really important for now
+    wcols = [v for v in fs.config.sections["GROUPS"].group_sections if "weight" in v]
+    num_wcols = len(wcols)
+    if num_wcols == 2:
+        for key in gtks:
+            fs.config.sections["GROUPS"].group_table[key]['vweight'] = 0.0
+
+    # population of generations
+    # population can't have odd numbers currently
+    if population_size % 2 == 1:
+        fs.pt.single_print("\n")
+        fs.pt.single_print(f"WARNING: Cannot use odd numbers for population size (input: {population_size})")
+        fs.pt.single_print(f"WARNING: Updating population_size: population_size +=1 (larger populations seem to perform better, in other GAs at least)")
+        fs.pt.single_print(f"WARNING: New population_size: {population_size+1})")
+        population_size += 1
+        fs.pt.single_print("\n")
+
+    # start getting weights 
+    initial_weights={}
+    if use_initial_weights_flag:
+        for key in gtks:
+            initial_weights[key] = [fs.config.sections["GROUPS"].group_table[key]['eweight'], fs.config.sections["GROUPS"].group_table[key]['fweight'], \
+                                    fs.config.sections["GROUPS"].group_table[key]['vweight']]
+
+    size_b = np.shape(fs.pt.fitsnap_dict['Row_Type'])[0]
+    grouptype = fs.pt.fitsnap_dict['Groups'].copy()
+    rowtype = fs.pt.fitsnap_dict['Row_Type'].copy()
+
+    countmaxtot = int(population_size*(ngenerations+2))
+    seedsi = seed_maker(fs, countmaxtot)
+
+    #number of hyperparameters:
+    # num of energy group weights
+    ne = len(gtks)
+    # num of force group weights
+    nf = ne
+    ns = ne
+    # total
+    if not my_es_ratios:
+        nh = ne + nf
+    else:
+        nh = ne + nf + ns
+
+    # update ranges and ratios
+    eranges = [my_w_ranges]
+    ffactors = [my_ef_ratios]
+    sfactors = [my_es_ratios]  ##LOGAN NOTE: EMPTY LIST IF NOT USING
+
+    # selection method (only tournament is currently implemented)
+    # TODO implement other methods?
+    selection_method = 'tournament'
+
+    # modify convergence check for new conv_flag
+    check_gen = int((ngenerations/conv_check))
+
+    # End optimization hyperparameters
+    #---------------------------------------------------------------------------
+
+    # set up generation 0
+    best_eval = 9999999.9999
+    conv_flag = False
+    first_seeds = seedsi[:population_size+1]
+    hp = HyperparameterStruct(ne,nf,ns,eranges,ffactors,sfactors)
+
+    # population = [hp.random_params(inputseed=first_seeds[ip]) for ip in range(population_size)] # TODO orig
+
+    # Random initial population for first generation:
+    #population = [hp.random_params(inputseed=first_seeds[ip]) for ip in range(population_size)]
+    # Latin hypercube population for first generation:
+    population = hp.lhs_params(num_samples=population_size,inputseed=first_seeds[0])
+
+    generation = 0
+
+    best_evals = [best_eval]
+    best = tuple(population[0])
+    sim_seeds = seedsi[population_size:]
+    np.random.seed(sim_seeds[generation])
+    w_combo_delta = np.ones(len(gtks))
+
+    # delta function to zero out force weights on structures without forces  
+    # now implemented with user-specified keywords
+    if force_delta_keywords != []:
+        not_in_fdkws = lambda gti: all([True if fdkw not in gti else False for fdkw in force_delta_keywords])
+        ef_rat_delta = np.array([1.0 if not_in_fdkws(gti) else 0.0 for gti in gtks])
+    else:
+        ef_rat_delta = np.array([1.0]*len(gtks))
+
+    if stress_delta_keywords != [] or len(stress_delta_keywords) == len(gtks):
+        not_in_fdkws = lambda gti: all([True if fdkw not in gti else False for fdkw in stress_delta_keywords])
+        es_rat_delta = np.array([1.0 if not_in_fdkws(gti) else 0.0 for gti in gtks])
+    else:
+        es_rat_delta = np.array([1.0]*len(gtks))
+        
+    while generation <= ngenerations and best_eval > conv_thr and not conv_flag:
+        scores = []
+        # current generation
+        for creature in population:
+            creature_ew, creature_ffac, creature_sfac = tuple(creature.reshape(3,ne).tolist())
+            creature_ew = tuple(creature_ew)
+            creature_ffac = tuple(creature_ffac)
+            creature_sfac = tuple(creature_sfac)
+
+            ##LOGAN NOTE: should confirm this is working as expected (always multiplying factor by initial weight and not a previous generation product by initial weight)
+            update_weights(fs, creature_ew, creature_ffac, creature_sfac, gtks, size_b, grouptype,initial_weights=initial_weights)
+            costi = fit_and_cost(fs,[etot_weight,ftot_weight,stot_weight])
+            scores.append(costi)
+
+            #NOTE to add another contribution to the cost function , you need to evaluate it in the loop
+            # and add it to the fit_and_cost function
+            # if this involves a lammps simulation, you will have to print potentials at the different steps
+            # to run the lammps/pylammps simulation. To do so, the fitsnap output file name prefix should
+            # be updated per step, then fs.write_output() should be called per step. This will likely increase
+            # the optimization time.
+        # Anything printed with fs.pt.single_print will be included in output file.
+        fs.pt.single_print('Generation, scores, popsize:',generation,len(scores),population_size)
+
+        # Print generation and best fit.
+        # bestfit = min(scores)
+        # print(f"{generation} {bestfit}")
+        for i in range(population_size):
+            if scores[i] < best_eval:
+                best, best_eval = tuple(population[i]), scores[i]
+        best_evals.append(best_eval)
+        try:
+            ## Original flag
+            conv_flag = np.round(np.var(best_evals[int(ngenerations/conv_check)-int(ngenerations/10):]),14) == 0
+            ## New flag, currently testing
+            # conv_flag = np.round(np.var(best_evals[-(check_gen*math.floor(len(best_evals)/check_gen)):]),14) == 0
+        except IndexError:
+            conv_flag = False
+        printbest = tuple([tuple(ijk) for ijk in np.array(best).reshape(3,ne).tolist()])
+        fs.pt.single_print('\n')
+        fs.pt.single_print('Generation:',generation, 'score:', scores[i])
+
+        # TODO input user's settings or warn user that it will be overwritten (train_sz, test_sz)
+        print_final(fs, gtks, printbest)
+        slct = Selector(selection_style = selection_method)
+        selected = [slct.selection(population, scores) for creature_idx in range(population_size)]
+        del slct
+
+        # new generation
+        children = list()
+        for ii in range(0, population_size, 2):
+            # get selected parents in pairs
+            p1, p2 = selected[ii], selected[ii+1]
+            # crossover and mutation
+            rndcross, rndmut = tuple(np.random.rand(2).tolist())
+            if rndcross <= r_cross:
+                cs = crossover(p1, p2, len(gtks), w_combo_delta, ef_rat_delta, es_rat_delta)
+            else:
+                cs = [p1,p2]
+            for c in cs:
+                # mutation
+                if rndmut <= r_mut:
+                    current_creature_ew, current_creature_ffac, current_creature_sfac = tuple(c.reshape(3,ne))
+                    current_creature_ew = tuple(current_creature_ew)
+                    current_creature_ffac = tuple(current_creature_ffac)
+                    current_creature_sfac = tuple(current_creature_sfac)
+
+                    mutated_creature_ew, mutated_creature_ffac, mutated_creature_sfac = mutation(current_creature_ew,current_creature_ffac,current_creature_sfac,\
+                                                                                                 my_w_ranges,my_ef_ratios,my_es_ratios,ng=len(gtks),\
+                                                                                                 w_combo_delta=w_combo_delta,ef_rat_delta=ef_rat_delta, s_combo_delta=es_rat_delta,\
+                    apply_random=True,
+                    full_mutation=False)
+
+                    c = np.concatenate((mutated_creature_ew,mutated_creature_ffac,mutated_creature_sfac))
+                    # store for next generation
+                children.append(c)
+        generation += 1
+        np.random.seed(sim_seeds[generation])
+        population = children
+    best_ew, best_ffac, best_sfac = tuple(np.array(best).reshape(3,ne).tolist())
+    best_ew = tuple(creature_ew)
+    best_ffac = tuple(creature_ffac)
+    best_sfac = tuple(creature_sfac)
+
+    ##LOGAN NOTE: should confirm this is working as expected (always multiplying factor by initial weight and not a previous generation product by initial weight)
+    update_weights(fs, best_ew, best_ffac, best_sfac, gtks, size_b, grouptype, initial_weights=initial_weights)
+    costi = fit_and_cost(fs,[etot_weight,ftot_weight,stot_weight])
+    print_final(fs, gtks, tuple([best_ew,best_ffac,best_sfac]), write_to_json=write_to_json)
+    time2 = time.time()
+    elapsed = round(time2 - time1, 2)
+    fs.pt.single_print(f'Total optimization time: {elapsed} s')
+    fs.pt.single_print('Writing final output')
+    fs.write_output()

--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -694,15 +694,23 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         fs: FitSnap instance being handled by genetic algorithm
         population_size: number of candidates ("creatures") generated within one generation and tested for fitness. in this code, fitness is how well group weights perform in a FitSnap fit (no puns intended)
         ngenerations: maximum number of allowed iterations of populations. this ends the genetic algorithm calculations if the convergence threshold (conv_thr, see below) is not reached beforehand
-        my_w_ranges: allowed scaling factors for energy weights
-        my_ef_ratios: allowed scaling factors for force weights
-        etot_weight and ftot_weight: weights for energy and force rmse in the optimizer cost function
+        my_w_ranges, my_ef_ratios, my_es_ratios: allowed scaling factors for energy, force, and stress weights
+        etot_weight, ftot_weight, stot_weight: weights for energy and force rmse in the optimizer cost function
         r_cross and r_mut: cross over (parenting) and mutation hyperparameters
         conv_thr: convergence threshold for full function (value of RMSE E + RMSE F at which simulation is terminated" 
         conv_check: fraction of ngenerations to start checking for convergence (convergence checks wont be performed very early)
+        force_delta_keywords, stress_delta_keywords: 
+        write_to_json: whether to write the final best fit to a new FitSNAP settings dictionary to a JSON file
+        use_initial_weights_flag: whether to bias fitting with initial_weights 
+        parallel_population: whether to use MPI*/split communicator when ncores > 1
 
     Returns:
         (none, prints best group weights to stdout and/or a JSON file)
+
+    *When using MPI, a quick note on number of cores P: 
+    - For now, it's best to use an even number of cores P.
+    - If your population_size setting is smaller than P, it will be increased to P (to avoid running empty cores per generation).
+    - If you're using MPI but don't want to run the GA in parallel, set the optional genetic_algorithm argument `parallel_population = False.`
     """
     #---------------------------------------------------------------------------
     # Begin in-function optimization hyperparameters
@@ -914,7 +922,6 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         # loop through creatures in current generation          
         gen_start = time.time()
         for i, creature in enumerate(pop_list):           
-
             # get creature values from generated population
             creature_ew, creature_ffac, creature_sfac = tuple(creature.reshape((num_wcols,ne)).tolist())  
             creature_ew = tuple(creature_ew)

--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -615,7 +615,7 @@ def assign_ranks(population0, ncores):
     population = [[] for _ in range(ncores)]
     pop_indices = [[] for _ in range(ncores)] 
     for i, creature in enumerate(population0):
-        # assign creatures alternating cores (odd creatures => odd cores)
+        # assign creatures alternating cores 
         rank_i = i % ncores 
         population[rank_i].append(creature) 
         pop_indices[rank_i].append(i)
@@ -932,7 +932,7 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         # unpack in same order as MPI grid assignment
         flat_scores = collect_scores.flatten().tolist()
         flat_pop_indices = [item for items in pop_indices for item in items]
-        scores = [flat_scores[i] for i in flat_pop_indices]
+        scores = [flat_scores[flat_pop_indices.index(i)] for i in range(population_size)]
 
         # NOTE from James: to add another contribution to the cost function, you need to evaluate it in the loop
         # and add it to the fit_and_cost function
@@ -946,7 +946,6 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         # Print generation and best fit.
         lowest_score_in_gen = 1e10
         for i in range(population_size):
-            print("DEBUG scores[i]", i, scores[i])
             if scores[i] < lowest_score_in_gen:
                 lowest_score_in_gen = scores[i]                
             if scores[i] < best_score:

--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -911,8 +911,10 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         collect_scores = np.full((scores_nrow, scores_ncol), 1e8)
         per_rank_scores = np.full(len(pop_list), 1e8)
 
-        # loop through creatures in current generation
+        # loop through creatures in current generation          
+        gen_start = time.time()
         for i, creature in enumerate(pop_list):           
+
             # get creature values from generated population
             creature_ew, creature_ffac, creature_sfac = tuple(creature.reshape((num_wcols,ne)).tolist())  
             creature_ew = tuple(creature_ew)
@@ -986,6 +988,7 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         except IndexError:
             conv_flag = False
         printbest = tuple([tuple(ijk) for ijk in np.array(best).reshape((num_wcols,ne)).tolist()])
+        
         fs.pt.single_print(f"------------ GENERATION {generation} ------------")
         fs.pt.single_print(f'Lowest score:', lowest_score_in_gen)
         print_final(fs, gtks, printbest, best_gens[-1], best_scores[-1])
@@ -1028,6 +1031,10 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         np.random.seed(sim_seeds[generation])
         population, pop_indices = assign_ranks(children, ncores)
         generation += 1
+        gen_end = time.time()
+        elapsed = round(gen_end - gen_start, 2)
+        fs.pt.single_print(f'Total time to compute generation (population_size {population_size}): {elapsed} s')
+        fs.pt.single_print('\n')
 
     # evolution completed, final steps
     # TODO add message describing whether ngenerations reached or conv_flag = True

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -8,6 +8,11 @@ Serial usage:
 Parallel usage:
 
     mpirun -n 2 python script_optimize.py 
+
+When using MPI, a quick note on number of cores P: 
+- For now, it's best to use an even number of cores P.
+- If your population_size setting is smaller than P, it will be increased to P (to avoid running empty cores per generation).
+- If you're using MPI but don't want to run the GA in parallel, set the optional genetic_algorithm argument `parallel_population = False.`
 """
 
 import os, time, argparse, warnings
@@ -35,8 +40,8 @@ def main():
     # Genetic algorithm parameters
     
     # basic parameters
-    population_size = 100 # <-- minimum 4 for testing, default is 100
-    ngenerations = 50 # <-- minimum 4 for testing, default is 50
+    population_size = 30 # <-- minimum 4 for testing, default is 100
+    ngenerations = 20 # <-- minimum 4 for testing, default is 50
 
     # Advanced parameters, see libmod_optimize.py genetic_algorithm arguments for defaults
     # set exploration ranges for energies and forces

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -29,13 +29,14 @@ def main():
     fs_input="SNAP_Ta.in"
     # fs_input="ACE_Ta.in"
     optimization_style = "genetic_algorithm"
+    INITIAL_FIT = False
 
     #---------------------------------------------------------------------------
     # Genetic algorithm parameters
     
     # basic parameters
-    population_size = 100 # <-- minimum 4 for testing, default is 100
-    ngenerations = 50 # <-- minimum 4 for testing, default is 50
+    population_size = 10 # <-- minimum 4 for testing, default is 100
+    ngenerations = 5 # <-- minimum 4 for testing, default is 50
 
     # Advanced parameters, see libmod_optimize.py genetic_algorithm arguments for defaults
     # set exploration ranges for energies and forces
@@ -96,25 +97,24 @@ def main():
     snap.scrape_configs()
     snap.process_configs()
     snap.pt.all_barrier()
-    snap.perform_fit()
-    fit1 = snap.solver.fit
-    errs1 = snap.solver.errors
 
-    # NOTE: when using MPI, the following lines may throw a warning error but the program will still run
-    rmse_e = errs1.iloc[:,2].to_numpy()
-    rmse_counts = errs1.iloc[:,0].to_numpy()
-    rmse_eat = rmse_e[0]
-    rmse_fat = rmse_e[1]
-    rmse_tot = rmse_eat + rmse_fat
-    snap.pt.single_print(f'Initial fit:\n\trsme energies: {rmse_eat}\n\trsme forces: {rmse_fat}\n\t total:{rmse_tot}')
+    if INITIAL_FIT:
+        snap.perform_fit()
+        fit1 = snap.solver.fit
+        errs1 = snap.solver.errors
+
+        # NOTE: when using MPI, the following lines may throw a warning error but the program will still run
+        rmse_e = errs1.iloc[:,2].to_numpy()
+        rmse_counts = errs1.iloc[:,0].to_numpy()
+        rmse_eat = rmse_e[0]
+        rmse_fat = rmse_e[1]
+        rmse_tot = rmse_eat + rmse_fat
+        snap.pt.single_print(f'Initial fit:\n\trsme energies: {rmse_eat}\n\trsme forces: {rmse_fat}\n\t total:{rmse_tot}')
 
     snap.solver.fit = None
 
     snap.pt.single_print("FitSNAP optimization algorithm: ",args.optimization_style)
-
-    if optimization_style == 'simulated_annealing':
-        lm_opt.sim_anneal(snap)
-    elif optimization_style == 'genetic_algorithm':
+    if optimization_style == 'genetic_algorithm':
        lm_opt.genetic_algorithm(snap, 
                                 population_size=population_size, 
                                 ngenerations=ngenerations, 
@@ -132,6 +132,8 @@ def main():
                                 stress_delta_keywords=force_delta_keywords,
                                 write_to_json=write_to_json,
                                 use_initial_weights_flag=use_initial_weights)
+    elif optimization_style == 'simulated_annealing':
+        lm_opt.sim_anneal(snap)
     snap.pt.single_print("Script complete, exiting")
 
 if __name__ == "__main__":

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -1,13 +1,13 @@
 """
-Genetic algorithm optimization of SNAP potential
+Genetic algorithm to optimize group weights in FitSNAP fits
 
 Serial usage:
 
-    python libmod_optimize.py # --fitsnap_in Ta-example.in --optimization_style genetic_algorithm
+    python script_optimize.py 
 
 Parallel usage:
 
-    mpirun -n 2 python libmod_optimize.py # --fitsnap_in Ta-example.in --optimization_style genetic_algorithm
+    mpirun -n 2 python script_optimize.py 
 """
 
 import os, time, argparse, warnings
@@ -29,14 +29,14 @@ def main():
     fs_input="SNAP_Ta.in"
     # fs_input="ACE_Ta.in"
     optimization_style = "genetic_algorithm"
-    INITIAL_FIT = False
+    perform_initial_fit = False
 
     #---------------------------------------------------------------------------
     # Genetic algorithm parameters
     
     # basic parameters
-    population_size = 10 # <-- minimum 4 for testing, default is 100
-    ngenerations = 5 # <-- minimum 4 for testing, default is 50
+    population_size = 100 # <-- minimum 4 for testing, default is 100
+    ngenerations = 50 # <-- minimum 4 for testing, default is 50
 
     # Advanced parameters, see libmod_optimize.py genetic_algorithm arguments for defaults
     # set exploration ranges for energies and forces
@@ -44,7 +44,7 @@ def main():
     my_ef_ratios = [0.001,0.01,0.1,1,10,100,1000]
     my_es_ratios = [0.001,0.01,0.1,1,10,100,1000]
     
-    # scaling of weights
+    # scaling of weights relative to each other
     etot_weight = 1.0
     ftot_weight = 1.0
     stot_weight = 1.0
@@ -54,41 +54,32 @@ def main():
     r_mut = 0.1
 
     # set a score threshold for convergence 
-    # TODO: need better explanation of what the score is
-    # NOTE: could also have this operate on MAE or RMSE instead of score?
+    # TODO: need an explanation of what the score is
     conv_thr = 1.E-10
 
-    # set a minimum value of ngenerations to run before checking for convergence (int(ngenerations/conv_check)).
-    # example: if ngenerations = 100 and conv_check = 2, then convergence will only start being checked after half of the generations have been calculated (50 = 100/2).
-    # make this number smaller to check for convergence earlier, and larger for later
-    # tested defaults are between 2 and 3.
-    conv_check = 2.
+    # set a fraction of ngenerations to check for score convergence
+    # example: if ngenerations = 100 and conv_check = 0.5, then convergence will only start being checked at generation 51, after half of the generations have been calculated. 
+    # make this number smaller to check for convergence earlier, and larger for later.
+    # tested defaults are between 0.33 to 0.5.
+    conv_check = 0.5
 
     # set designated group's force weights to zero (e.g. volume transformations)
     force_delta_keywords = []
     stress_delta_keywords = []
     
     # write final best generation to FitSnap-compatible JSON dictionary. default is False
-    write_to_json = True 
+    write_to_json = False 
     
     # use_initial_weights reads from current file, default is False
     ### TODO test this!
-    use_initial_weights = True 
+    use_initial_weights = False 
     
     # End genetic algorithm parameters
     #---------------------------------------------------------------------------
-    parser = argparse.ArgumentParser(description='FitSNAP example.')
-    parser.add_argument("--fitsnap_in", help="FitSNAP input script.", default=fs_input)
-    parser.add_argument("--optimization_style", help="optimization algorithm: 'simulated_annealing' or 'genetic_algorithm' ", default=optimization_style)
-    args = parser.parse_args()
-
-    optimization_style = args.optimization_style
-
-    settings = args.fitsnap_in
 
     # Create a FitSnap instance using the communicator and settings:
-    snap = FitSnap(settings, comm=comm, arglist=["--overwrite"])
-    snap.pt.single_print("FitSNAP input script:", args.fitsnap_in)
+    snap = FitSnap(fs_input, comm=comm, arglist=["--overwrite"])
+    snap.pt.single_print("FitSNAP input script:", fs_input)
 
     # prepare snap config for genetic algorithm
     lm_opt.prep_fitsnap_input(snap)
@@ -98,7 +89,9 @@ def main():
     snap.process_configs()
     snap.pt.all_barrier()
 
-    if INITIAL_FIT:
+    # use can decide whether or not to perform fit with initial fs_input settings
+    # this is useful if one would like to compare the original model with a resulting model
+    if perform_initial_fit:
         snap.perform_fit()
         fit1 = snap.solver.fit
         errs1 = snap.solver.errors
@@ -113,7 +106,8 @@ def main():
 
     snap.solver.fit = None
 
-    snap.pt.single_print("FitSNAP optimization algorithm: ",args.optimization_style)
+    # perform optimization algorithms 
+    snap.pt.single_print("FitSNAP optimization algorithm: ",optimization_style)
     if optimization_style == 'genetic_algorithm':
        lm_opt.genetic_algorithm(snap, 
                                 population_size=population_size, 
@@ -132,8 +126,13 @@ def main():
                                 stress_delta_keywords=force_delta_keywords,
                                 write_to_json=write_to_json,
                                 use_initial_weights_flag=use_initial_weights)
-    elif optimization_style == 'simulated_annealing':
-        lm_opt.sim_anneal(snap)
+   
+    # TODO implement other SNAP optimizations
+    # elif optimization_style == 'simulated_annealing':
+    #     # tODO integrate MPI and other new fixes into simulated annealing
+    #     lm_opt.sim_anneal(snap)
+    # elif optimization_style == 'latin_hypercube':
+    #     lm_opt.latin_hypercube_sample(snap)
     snap.pt.single_print("Script complete, exiting")
 
 if __name__ == "__main__":

--- a/tools/input_to_settings_dict.py
+++ b/tools/input_to_settings_dict.py
@@ -1,34 +1,57 @@
 """
-Script to convert a FitSNAP input file to a dictionary
-Dictonary is printed to stdout and can be copied directly into a FitSNAP script
-If write_json = True, also writes the dictionary to a JSON file
+---> Script to convert a FitSNAP input file to a dictionary <---
+Dictonary is printed to stdout and can be copied directly into a FitSNAP script, and can optionally be written to a Python file.
+
+If write_python_dict = True, writes the dictionary as a variable 'input_dict' to a Python file, which can be copied or imported into any FitSNAP script.
+The output file name will be automatically generated based on the infile name.
+Optionally, you can also choose your own "output_label" (no need to add file formats, those are added later).
+
 """
 import os, configparser, json
 
-infile = "fitsnap.in"
-write_json = True
+# ------------------- user settings
+
+# REQUIRED: name of FitSNAP input 
+infile = "SNAP_Ta.in"
+
+# OPTIONAL: write to a Python file as a variable 'input_dict'
+write_python_dict = True
+
+# OPTIONAL: choose a label for *.json or *.py output (file format will be appended)
+# if this is left empty ('' or None or 0 or [] or ...), a name will be automatically generated
+outfile_label = "" 
+
+# ------------------- run script
+
+# if user doesn't choose a name for the output file, use infile label
+if not outfile_label:
+  infile_label = infile.replace(".","").replace("in","")
+  outfile_label = f'settings_{infile_label}'
 
 if not os.path.exists(infile):
   print(f"Could not locate FitSNAP input file '{infile}'!\nChange variable 'infile' in script and run again.")
   exit()
 
-## you can use the next 3 lines to generate the settings dictionary directly inside a python script
+# you can use the next 3 lines to generate the settings dictionary directly inside a python script
+# the c.optionxform = str line makes sure that string cases are conserved on read-in
 c = configparser.ConfigParser()
+c.optionxform = str 
 c.read(infile)
 settings = {s:dict(c.items(s)) for s in c.sections()}
-    
-## you can use this next line to print out a pretty looking version of the dictionary as a JSON
-## it should be valid code that you can copy-paste into a python script and run
+
+# you can use this next line to print out a pretty looking version of the settings dictionary
+# it should be valid code that you can copy-paste into a python script and run
 print(json.dumps(settings, indent=4))
 
-## if you want, can also write to a JSON file 
-## see note at bottom about reading the JSON file in FitSNAP or another program
-if write_json:
-  outfile = f"{infile}.json"
+# write Python file with 'input_dict' dictionary variable
+# this can be copied from the file, or imported as a module, e.g.:
+# from settings_fitsnap-in import input_dict
+if write_python_dict:
+  outfile = f"{outfile_label}.py"
   with open(outfile, 'w') as f:
+    f.write("# Settings dictionary for FitSNAP input, to use:\n")
+    f.write(f"# from {outfile_label} import input_dict\n")
+    f.write("input_dict = \\")
+    f.write("\n")
     json.dump(settings, f, indent=4)
   print(f"Wrote '{infile}' dict to output file: ", outfile)
-
-## to read JSON file, use:
-## with open(outfile, 'r') as f:
-##  new_dict_object = json.loads(f.read())

--- a/tools/input_to_settings_dict.py
+++ b/tools/input_to_settings_dict.py
@@ -1,10 +1,13 @@
 """
 ---> Script to convert a FitSNAP input file to a dictionary <---
-Dictonary is printed to stdout and can be copied directly into a FitSNAP script, and can optionally be written to a Python file.
+(complements settings_dict_to_input.py)
+Dictonary is printed to stdout which can be copied into FitSNAP library scripts, and can optionally be written to a Python file.
 
-If write_python_dict = True, writes the dictionary as a variable 'input_dict' to a Python file, which can be copied or imported into any FitSNAP script.
+There are two file formats that you can write to, *.py and *.json.
 The output file name will be automatically generated based on the infile name.
 Optionally, you can also choose your own "output_label" (no need to add file formats, those are added later).
+If write_python_dict = True, writes the dictionary as a variable 'input_dict' to a Python file, which can be copied or imported into any FitSNAP script.
+If write_json = True, writes the dictionary to a JSON file, which can be copied or read into any FitSNAP script using the native Python json module.
 
 """
 import os, configparser, json
@@ -14,8 +17,9 @@ import os, configparser, json
 # REQUIRED: name of FitSNAP input 
 infile = "SNAP_Ta.in"
 
-# OPTIONAL: write to a Python file as a variable 'input_dict'
+# OPTIONAL: write to a Python file as a variable 'input_dict' or a standard JSON file
 write_python_dict = True
+write_json = True
 
 # OPTIONAL: choose a label for *.json or *.py output (file format will be appended)
 # if this is left empty ('' or None or 0 or [] or ...), a name will be automatically generated
@@ -55,3 +59,17 @@ if write_python_dict:
     f.write("\n")
     json.dump(settings, f, indent=4)
   print(f"Wrote '{infile}' dict to output file: ", outfile)
+
+## if you want, can also write to a JSON file 
+## see note at bottom about reading the JSON file in FitSNAP or another program
+if write_json:
+  outfile = f"{infile}.json"
+  with open(outfile, 'w') as f:
+    json.dump(settings, f, indent=4)
+  print(f"Wrote '{infile}' dict to output file: ", outfile)
+
+# to read JSON file in any program, use:
+# with open(outfile, 'r') as f:
+#  new_dict_object = json.loads(f.read(), strict=False)
+#
+# Note: sometimes need the strict=False argument cause json.loads borks on newlines

--- a/tools/settings_dict_to_input.py
+++ b/tools/settings_dict_to_input.py
@@ -1,0 +1,71 @@
+"""
+---> Script to convert a FitSNAP settings dictionary to an input file <---
+(complements input_to_settings_dict.py)
+This script can take a settings dictionary (copied directly here, or read from a JSON or Python* file) and writes a standard FitSNAP input file.
+  
+Optionally, you can also choose your own "output_label" (no need to add file formats, those are added later).
+If "output_label" is left empty, the output file name will be simply 'fitsnap.in'
+If print_to_screen = True, prints the new input file to screen.
+
+*Note: Python files must contain only the FitSNAP settings dictionary, written as a variable - i.e. input_dict = {...}!
+"""
+import os, configparser, json
+
+# ------------------- user settings
+# REQUIRED: FitSNAP settings dictionary for input
+input_dict = "settings_SNAP_Ta.py"
+# NOTE: two formats are accepted - either:
+#   - a FitSNAP settings dictionary, OR
+#   - a string such as "fitsnap_settings.json" OR "fitsnap_settings.py"
+# Note that the JSON or Python file must contain ONLY the input_dict object!
+
+# OPTIONAL: choose a label for your file, i.e. my_fancy_file (no file format needed)
+# if this is left empty ('' or None or 0 or [] or ...), a name will be automatically generated
+outfile_label = "" 
+
+# OPTIONAL: print new file to screen
+print_to_screen = True
+
+# ------------------- run script
+
+# if user doesn't choose a name for the output file, use infile label
+if not outfile_label:
+  outfile_label = 'fitsnap'
+
+outfile = f'{outfile_label}.in'
+
+# If no input_dict is specified, check if an input file was specified.
+if type(input_dict) == str:
+  if not os.path.exists(input_dict):
+    print(f"Could not locate any infile '{input_dict}'!\nChange variable 'infile' in script and run again.")
+    exit()
+  else:
+    with open(input_dict, 'r') as f:
+      if '.json' in input_dict:
+        txt = f.read()
+      elif ".py" in input_dict:
+        txt0 = f.read()
+        start_dict_idx = txt0.find("{")
+        txt = txt0[start_dict_idx:]
+        
+    input_dict = json.loads(txt, strict=False)
+
+# the configparser formats the dictionary for proper FitSNAP read-in
+# the c.optionxform = str line makes sure that string cases are conserved on read-in
+c = configparser.ConfigParser()
+c.optionxform = str 
+for k, v in input_dict.items():
+  c[k] = v
+
+# have the configparser write the file to disk
+with open(outfile, 'w') as f:
+  c.write(f)
+print(f"Wrote input_dict to output file: ", outfile)
+
+# this prints the file line-by-line to screen (stdout)
+if print_to_screen:
+  print(f"Printing FitSNAP input file: {outfile}")
+  with open(outfile, 'r') as f:
+    txt = f.readlines()
+  for line in txt:
+    print(line.strip())


### PR DESCRIPTION
This PR is a minor overhaul of libmod_optimize.py in the genetic_algorithm (GA) library example.
The main goal is to add parallel processing of all "creatures" (the members of a population) within each generation using mpi4py.
Computing each generation's population in parallel leads to significant speedups* of the GA, allowing much higher throughput.
This is made possible by creating a second FitSNAP instance per generation that has a split MPI communicator.
To use: `mpirun -np P python script_optimize.py`
Note: that the genetic_algorithm will _increase_ the `population_size` variable to be compatible with the number of cores used!

Other changes in this PR include:
- Fixing a major bug in reshaping weight arrays 
- Adding more comments and documentation
- Updating convergence flag 
- Adding a few helpful print statements for output
- Commenting out the simulated annealing functions for now
- Slight streamlining in using initial weights
- Updating the input_to_settings_dict.py tool, and adding a complementary settings_dict_to_input.py tool (for automation of fitting and reading FitSNAP settings)

Thanks to @jmgoff (original author), @rohskopf, and @ldwillia for help/additions!

*Speedup: In serial, the time taken to run the GA is approximately 'population_size * time_per_creature * ngenerations.`  
In parallel, this time is divided by the number of cores P (speedup factor of \~P).

Example: we have 30 creatures per population, need 10s per creature, and want to run 20 generations, the GA will take 6000 seconds (about 1.7 hours) in serial mode.
With 2 MPI cores: 3000 s (\~50 minutes)
With 20 MPI cores: 300 s (\~5 minutes!)