### PR TITLE
Adding in a prototype of elastic constant test to genetic algo script

### DIFF
--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -467,6 +467,10 @@ def fit_and_cost(fs, fitobjects, costweights, additional_cost_functions=[],addit
     CO.add_contribution(rmse_fattst,ftot_weight)
     CO.add_contribution(rmse_sattst,stot_weight)
 
+    ## LOGAN NOTE: TO BE REMOVED WHEN CODE IS BETTER! (currently needed for the additional cost functions, which read files rather than get passed the fitted model)
+    if len(additional_cost_functions) > 0:
+        fs.write_output()
+    
     # add additional costs from the additional_cost_functions
     for j, cost_function in enumerate(additional_cost_functions):
         additional_costs = cost_function.output_errors()

--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -58,6 +58,7 @@ class CostObject:
         return costi
 
 class ElasticPropertiesFromLAMMPS:
+    ## This is NOT set up to be usable in parallel yet! 
     def __init__(self, lammps_executable_path, lammps_script_filename, truth_values=False, existing_output_path=False):
         self.names = ["abs_error_lattice_parameter", "abs_error_C11", "abs_error_C12", "abs_error_C44"]  ##labels for what this class outputs as a cost function
         self.calculated_values = False

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -43,6 +43,8 @@ def main():
     optimization_style = args.optimization_style
     perform_initial_fit = args.perform_initial_fit
 
+    # verbose flag prints out much more info per tested fit
+    verbose = True
     #---------------------------------------------------------------------------
     # Genetic algorithm parameters
     
@@ -157,7 +159,8 @@ def main():
                                 write_to_json=write_to_json,
                                 use_initial_weights_flag=use_initial_weights,
                                 additional_cost_functions = additional_cost_functions,
-                                additional_cost_weights = additional_cost_weights)
+                                additional_cost_weights = additional_cost_weights,
+                                verbose=verbose)
    
     # TODO implement other SNAP optimizations
     # elif optimization_style == 'simulated_annealing':

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -31,9 +31,15 @@ def main():
     size = comm.Get_size()
 
     # parse command line args
-    fs_input="SNAP_Ta.in"
+    parser = argparse.ArgumentParser(description='FitSNAP example.')
+    parser.add_argument("--fitsnap_in", help="FitSNAP input script.", default="SNAP_Ta.in")
+    parser.add_argument("--optimization_style", help="optimization algorithm: 'simulated_annealing' or 'genetic_algorithm' ", default="genetic_algorithm")
+    args = parser.parse_args()
+
+    fs_input=args.fitsnap_in
+    # fs_input="SNAP_Ta.in"
     # fs_input="ACE_Ta.in"
-    optimization_style = "genetic_algorithm"
+    optimization_style = "genetic_algorithm"  ##Make equal to args.optimization_style if we re-enable the simulated anneal
     perform_initial_fit = False
 
     #---------------------------------------------------------------------------

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -34,7 +34,7 @@ def main():
     parser = argparse.ArgumentParser(description='FitSNAP example.')
     parser.add_argument("--fitsnap_in", help="FitSNAP input script.", default="SNAP_Ta.in")
     parser.add_argument("--optimization_style", help="optimization algorithm: 'simulated_annealing' or 'genetic_algorithm' ", default="genetic_algorithm")
-    parser.add_argument("--perform_initial_fit", help="whether to train a model with starting parameters for comparison.", default=False)
+    parser.add_argument("--perform_initial_fit", action=argparse.BooleanOptionalAction) ##default is false
     args = parser.parse_args()
 
     fs_input=args.fitsnap_in

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -118,6 +118,24 @@ def main():
 
     snap.solver.fit = None
 
+    additional_cost_functions = []
+    additional_cost_weights = []
+    
+    # optional section for extra cost functions
+    lmp = "/usr/workspace/wsb/logwill/code/mylammps/build_v6_see_list/lmp"
+    lammps_elastic_input_script = "./in.elastic"
+    ## this bit reads in an output of a lammps calculation with a different model form as the truth. normally you would just set these values to exp or DFT data.
+    elastic_truth_output_filepath = "./truth_output"
+    reader = lm_opt.ElasticPropertiesFromLAMMPS(lmp, lammps_elastic_input_script, truth_values=False, existing_output_path=elastic_truth_output_filepath):
+    elastic_truth_vals = reader.output_vals()  ##this is where you would normally just set the vals. format: [lattice constant, C11, C12, C44]
+    del reader
+    additional_cost_functions.append(lm_opt.ElasticPropertiesFromLAMMPS(lmp, lammps_elastic_input_script, truth_values=elastic_truth_vals, existing_output_path=False))
+    lattice_weight = 1.0
+    C11_weight = 1.0
+    C12_weight = 100.0
+    C44_weight = 100.0
+    additional_cost_weights.append([lattice_weight, C11_weight, C12_weight, C44_weight])
+
     # perform optimization algorithms 
     snap.pt.single_print("FitSNAP optimization algorithm: ",optimization_style)
     if optimization_style == 'genetic_algorithm':
@@ -137,7 +155,9 @@ def main():
                                 force_delta_keywords=force_delta_keywords,
                                 stress_delta_keywords=force_delta_keywords,
                                 write_to_json=write_to_json,
-                                use_initial_weights_flag=use_initial_weights)
+                                use_initial_weights_flag=use_initial_weights,
+                                additional_cost_functions = additional_cost_functions,
+                                additional_cost_weights = additional_cost_weights)
    
     # TODO implement other SNAP optimizations
     # elif optimization_style == 'simulated_annealing':

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -34,13 +34,14 @@ def main():
     parser = argparse.ArgumentParser(description='FitSNAP example.')
     parser.add_argument("--fitsnap_in", help="FitSNAP input script.", default="SNAP_Ta.in")
     parser.add_argument("--optimization_style", help="optimization algorithm: 'simulated_annealing' or 'genetic_algorithm' ", default="genetic_algorithm")
+    parser.add_argument("--perform_initial_fit", help="whether to train a model with starting parameters for comparison.", default=False)
     args = parser.parse_args()
 
     fs_input=args.fitsnap_in
     # fs_input="SNAP_Ta.in"
     # fs_input="ACE_Ta.in"
-    optimization_style = "genetic_algorithm"  ##Make equal to args.optimization_style if we re-enable the simulated anneal
-    perform_initial_fit = False
+    optimization_style = args.optimization_style
+    perform_initial_fit = args.perform_initial_fit
 
     #---------------------------------------------------------------------------
     # Genetic algorithm parameters

--- a/examples/library/genetic_algorithm/script_optimize.py
+++ b/examples/library/genetic_algorithm/script_optimize.py
@@ -126,7 +126,7 @@ def main():
     lammps_elastic_input_script = "./in.elastic"
     ## this bit reads in an output of a lammps calculation with a different model form as the truth. normally you would just set these values to exp or DFT data.
     elastic_truth_output_filepath = "./truth_output"
-    reader = lm_opt.ElasticPropertiesFromLAMMPS(lmp, lammps_elastic_input_script, truth_values=False, existing_output_path=elastic_truth_output_filepath):
+    reader = lm_opt.ElasticPropertiesFromLAMMPS(lmp, lammps_elastic_input_script, truth_values=False, existing_output_path=elastic_truth_output_filepath)
     elastic_truth_vals = reader.output_vals()  ##this is where you would normally just set the vals. format: [lattice constant, C11, C12, C44]
     del reader
     additional_cost_functions.append(lm_opt.ElasticPropertiesFromLAMMPS(lmp, lammps_elastic_input_script, truth_values=elastic_truth_vals, existing_output_path=False))


### PR DESCRIPTION
First pass at a somewhat modular way to implement property tests in the genetic algorithm script.

Currently NOT set up for parallel calculation. It uses a class that holds the settings for the lammps (or whatever) test you want to do. A list of all these extra test classes and associated weights for their cost outputs gets passed from script_optimize to the genetic_algo call, which passes it on down to fit_and_cost. fit_and_cost now has a loop to run through all the extra test classes, calling their .output_errors() functions and adding them to the cost_object class. 

This overall architecture I think should be fine for parallel, but I am not familiar with lammps python mode, so it is currently just implemented using subprocess to run and capture the output of a very slightly modified version of the elastic properties example calculation script that is in the LAMMPS example folder. (I'll add those script files into here next commit.) The script reads the Ta_pot.* files, so multiple ones in parallel would overwrite each others output. The test class can have the run_lammps() rewritten to use the lammps python commands and passing along the fitted snap parameters instead of the scripts and snap output files to subprocess. That should allow for parallel operation without much difficulty, I think.


Other minor changes: added some verbose outputting of the cost object contributions controlled by a verbose flag up in script_optimize

(This builds off of my other previous small PR that added the argparser back into script_optimize for reading "-input_file Ta-example.in" and whatnot.)