### PR TITLE
Fix output bug in genetic_algorithm example

### DIFF
--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -354,7 +354,7 @@ def fit_and_cost(fs, fitobjects, costweights):
     CO.add_contribution(rmse_eattst,etot_weight)
     CO.add_contribution(rmse_fattst,ftot_weight)
     # CO.add_contribution(rmse_sattst,stot_weight)
-    
+
     calc_stress = fs.config.sections["CALCULATOR"].stress
     if calc_stress:
         CO.add_contribution(rmse_sattst,stot_weight)
@@ -888,6 +888,9 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
     fs_dict = fs.pt.fitsnap_dict
     grouptype = fs_dict["Groups"]
     
+    # initiate generation loop with 0th generation of creature-children
+    children = population0
+
     # begin evolution
     while generation <= ngenerations and best_score > conv_thr and not conv_flag:
         # toggle variable used to assign FitSNAP communicator (comm) type based on MPI state
@@ -971,10 +974,10 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
         for i in range(population_size):
             if scores[i] < lowest_score_in_gen:
                 lowest_score_in_gen = scores[i]  
-                lowest_weight_in_gen = population0[i]
+                lowest_weight_in_gen = children[i]
                 lowest_creature_idx = i        
             if scores[i] < best_score:
-                best, best_score, best_gen = tuple(population0[i]), scores[i], generation
+                best, best_score, best_gen = tuple(children[i]), scores[i], generation
         
         best_weights.append(best)
         best_gens.append(best_gen)
@@ -1006,7 +1009,7 @@ def genetic_algorithm(fs, population_size=50, ngenerations=100, my_w_ranges=[1.e
 
         # Choose/rank candidates for next generation
         slct = Selector(selection_style = selection_method)
-        selected = [slct.selection(population0, scores) for creature_idx in range(population_size)]
+        selected = [slct.selection(children, scores) for creature_idx in range(population_size)]
         del slct
 
         # new generation

--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -353,7 +353,11 @@ def fit_and_cost(fs, fitobjects, costweights):
     CO = CostObject()
     CO.add_contribution(rmse_eattst,etot_weight)
     CO.add_contribution(rmse_fattst,ftot_weight)
-    CO.add_contribution(rmse_sattst,stot_weight)
+    # CO.add_contribution(rmse_sattst,stot_weight)
+    
+    calc_stress = fs.config.sections["CALCULATOR"].stress
+    if calc_stress:
+        CO.add_contribution(rmse_sattst,stot_weight)
 
     # NOTE from James: commented examples on how to use energy differences in the objective function
     # a SINGLE structure is added to two new fitsnap groups, the corresponding energy

--- a/examples/library/genetic_algorithm/libmod_optimize.py
+++ b/examples/library/genetic_algorithm/libmod_optimize.py
@@ -333,6 +333,9 @@ def fit_and_cost(fs, fitobjects, costweights):
     etot_weight, ftot_weight, stot_weight = tuple(costweights)
     a, b, w, fs_dict = tuple(fitobjects)
 
+    # check if user is fitting stresses
+    calc_stress = fs.config.sections["CALCULATOR"].stress
+
     #clear old fit and solve test fit
     fs.solver.fit = None
     
@@ -347,15 +350,15 @@ def fit_and_cost(fs, fitobjects, costweights):
     # collect rmse errors for score
     # TODO: eventually refactor for different cost calculation methods, for now keep RMSE
     rmse_tst = errstst.iloc[:,2].to_numpy()
-    rmse_eattst, rmse_fattst, rmse_sattst = rmse_tst[0:3]
+    rmse_eattst, rmse_fattst = rmse_tst[:2]
+    if calc_stress:
+        rmse_sattst = rmse_tst[2]
 
     # calculate score 
     CO = CostObject()
     CO.add_contribution(rmse_eattst,etot_weight)
     CO.add_contribution(rmse_fattst,ftot_weight)
     # CO.add_contribution(rmse_sattst,stot_weight)
-
-    calc_stress = fs.config.sections["CALCULATOR"].stress
     if calc_stress:
         CO.add_contribution(rmse_sattst,stot_weight)
 


### PR DESCRIPTION
Major bug fix for the genetic algorithm example (thanks to @jmgoff for flagging it) - 
The current scoring system is a sum of the RMSEs for energies, forces, and (if fitting) stresses. 
However, the best score is not matching that sum of RMSEs in the final fit's error file ("metrics.md" for example). 
It turns out the best group weights per generation are being recorded from the initial population variable, instead of the current generation's one - the final printed "best weights" output is thus incorrect.

Changes are all in libmod_optimize.py: 
1. Corrects the variable(s) tracking the best-scoring population member ("creature") per generation; and
2. Adds logic to ensure that stress fitting settings from user are enforced 

If you've been using this version of the GA (parallel), please update your scripts with this version!