### PR TITLE
quick fix for PyTorch fits

### DIFF
--- a/fitsnap3lib/lib/neural_networks/pytorch.py
+++ b/fitsnap3lib/lib/neural_networks/pytorch.py
@@ -61,7 +61,7 @@ class FitTorch(torch.nn.Module):
         multi_element_option (int): Option for which multi-element network model to use.
     """
 
-    def __init__(self, networks, descriptor_count, force_bool, n_elements=1, multi_element_option=1, dtype=torch.float32):
+    def __init__(self, networks, descriptor_count, force_bool, n_elements=1, multi_element_option=1, single_flag=0, dtype=torch.float32):
         super().__init__()
 
         # pytorch does a nifty thing where each attribute here makes a unique key in state_dict
@@ -85,10 +85,11 @@ class FitTorch(torch.nn.Module):
         self.n_elem = n_elements
         self.multi_element_option = multi_element_option
 
+        #self.single_flag = False
         self.energy_bool = True
         self.force_bool = force_bool
 
-    def forward(self, x, xd, indices, atoms_per_structure, types, xd_indx, unique_j, unique_i, device, dtype=torch.float32):
+    def forward(self, x, xd, indices, atoms_per_structure, types, xd_indx, unique_j, unique_i, device, single_flag=0, dtype=torch.float32):
         """
         Forward pass through the PyTorch network model, calculating both energies and forces.
 
@@ -135,9 +136,8 @@ class FitTorch(torch.nn.Module):
         if (self.energy_bool):
             predicted_energy_total = torch.zeros(atoms_per_structure.size(), dtype=dtype).to(device)
             # Force 1D tensor even if have single element; necessary for index_add function.
-            #NOTE commented out to eliminate dimension mismatch errors
-            #if predicted_energy_total.size().numel() == 1:
-            #    predicted_energy_total = predicted_energy_total.unsqueeze(dim=0)
+            if predicted_energy_total.size().numel() == 1 and single_flag:
+                predicted_energy_total = predicted_energy_total.unsqueeze(dim=0)
             predicted_energy_total.index_add_(0, indices, per_atom_energies.squeeze())
         else:
             predicted_energy_total = None

--- a/fitsnap3lib/lib/neural_networks/pytorch.py
+++ b/fitsnap3lib/lib/neural_networks/pytorch.py
@@ -135,8 +135,9 @@ class FitTorch(torch.nn.Module):
         if (self.energy_bool):
             predicted_energy_total = torch.zeros(atoms_per_structure.size(), dtype=dtype).to(device)
             # Force 1D tensor even if have single element; necessary for index_add function.
-            if predicted_energy_total.size().numel() == 1:
-                predicted_energy_total = predicted_energy_total.unsqueeze(dim=0)
+            #NOTE commented out to eliminate dimension mismatch errors
+            #if predicted_energy_total.size().numel() == 1:
+            #    predicted_energy_total = predicted_energy_total.unsqueeze(dim=0)
             predicted_energy_total.index_add_(0, indices, per_atom_energies.squeeze())
         else:
             predicted_energy_total = None

--- a/fitsnap3lib/lib/sym_ACE/gen_labels.py
+++ b/fitsnap3lib/lib/sym_ACE/gen_labels.py
@@ -503,7 +503,7 @@ def generate_l_LR(lrng , rank , L_R = 0 , M_R = 0, use_permutations=True):
                 if flag:
                     ls.append(lstr % ltup)
         elif rank == 3:
-            nodes,remainder = tree(list(all_ls[0]))
+            nodes,remainder = tree(list(range(rank)))
             for ltup in all_ls:
                 inters = tree_l_inters(list(ltup) , L_R = L_R)
                 by_node = vec_nodes(ltup , nodes , remainder)
@@ -520,7 +520,7 @@ def generate_l_LR(lrng , rank , L_R = 0 , M_R = 0, use_permutations=True):
                         if lsub not in ls:
                             ls.append(lsub)
         elif rank == 4:
-            nodes,remainder = tree(list(all_ls[0]))
+            nodes,remainder = tree(list(range(rank)))
             for ltup in all_ls:
                 inters = tree_l_inters(list(ltup),L_R=L_R)
                 by_node = vec_nodes(ltup,nodes,remainder)
@@ -538,7 +538,7 @@ def generate_l_LR(lrng , rank , L_R = 0 , M_R = 0, use_permutations=True):
                             ls.append(lsub)
 
         elif rank == 5:
-            nodes,remainder = tree(list(all_ls[0]))
+            nodes,remainder = tree(list(range(rank)))
             for ltup in all_ls:
                 inters = tree_l_inters(list(ltup) , L_R = L_R)
                 by_node = vec_nodes(ltup,nodes,remainder)
@@ -556,7 +556,7 @@ def generate_l_LR(lrng , rank , L_R = 0 , M_R = 0, use_permutations=True):
                             ls.append(lsub)
 
         elif rank == 6:
-            nodes,remainder = tree(list(all_ls[0]))
+            nodes,remainder = tree(list(range(rank)))
             for ltup in all_ls:
                 inters = tree_l_inters(list(ltup) , L_R = L_R)
                 by_node = vec_nodes(ltup , nodes , remainder)
@@ -574,7 +574,7 @@ def generate_l_LR(lrng , rank , L_R = 0 , M_R = 0, use_permutations=True):
                             ls.append(lsub)
 
         elif rank == 7:
-            nodes,remainder = tree(list(all_ls[0]))
+            nodes,remainder = tree(list(range(rank)))
             for ltup in all_ls:
                 inters = tree_l_inters(list(ltup) , L_R = L_R)
                 by_node = vec_nodes(ltup , nodes , remainder)
@@ -592,7 +592,7 @@ def generate_l_LR(lrng , rank , L_R = 0 , M_R = 0, use_permutations=True):
                             ls.append(lsub)
 
         elif rank == 8:
-            nodes,remainder = tree(list(all_ls[0]))
+            nodes,remainder = tree(list(range(rank)))
             for ltup in all_ls:
                 inters = tree_l_inters(list(ltup) , L_R = L_R)
                 by_node = vec_nodes(ltup , nodes , remainder)

--- a/fitsnap3lib/solvers/pytorch.py
+++ b/fitsnap3lib/solvers/pytorch.py
@@ -42,7 +42,7 @@ try:
 
             self.global_fraction_bool = self.config.sections['PYTORCH'].global_fraction_bool
             self.training_fraction = self.config.sections['PYTORCH'].training_fraction
-
+            self.single_flag = 0
             self.multi_element_option = self.config.sections["PYTORCH"].multi_element_option
             if (self.config.sections["CALCULATOR"].calculator == "LAMMPSSNAP"):
                 self.num_elements = self.config.sections["BISPECTRUM"].numtypes
@@ -78,7 +78,9 @@ try:
                                       self.force_bool,
                                       self.num_elements,
                                       self.multi_element_option,
+                                      self.single_flag,
                                       self.dtype)
+                                      
             elif (self.pt.fitsnap_dict['per_atom_scalar']):
                 self.model = FitTorchPAS(self.networks,
                                          self.num_desc_per_element,
@@ -795,10 +797,10 @@ try:
 
                         #unique_i = dbdrindx[:,0]
                         #unique_j = dbdrindx[:,1]
-
+                        single_flag = 1
                         (e_model,f_model) = self.model(descriptors, dgrad, indices, num_atoms, 
                                                       atom_types, dbdrindx, unique_j, unique_i, 
-                                                      eval_device, dtype)
+                                                      eval_device, single_flag, dtype)
                         energies.append(e_model)
                         forces.append(f_model)
 


### PR DESCRIPTION
For now, removes the reshape of the ` predicted_energy_total ` tensor - which leads to mismatch in tensor sizes later in PyTorch fits.

Adds a quick fix so that ACE examples (PyTorch or otherwise) can be ran even if 0 descriptors are generated based on lmin and lmax. More detailed warnings, graceful errors, and docs will be added in a later PR.

