### PR TITLE
Quick patch for PyTorch solver fix

### DIFF
--- a/fitsnap3lib/solvers/pytorch.py
+++ b/fitsnap3lib/solvers/pytorch.py
@@ -734,10 +734,10 @@ try:
 
                     #unique_i = dbdrindx[:,0]
                     #unique_j = dbdrindx[:,1]
-
+                    single_flag=1
                     (energies,forces) = self.model(descriptors, dgrad, indices, num_atoms, 
                                                   atom_types, dbdrindx, unique_j, unique_i, 
-                                                  eval_device, dtype)
+                                                  eval_device, single_flag, dtype)
 
                 else:
                     


### PR DESCRIPTION
A 'single_flag' wasn't specified for some cases of the pytorch NN solver use in the last example fix PR. This led to errors in some Pytorch NN fit examples. 

The flag was added to a final place in the pytorch solver to resolve this.