### PR TITLE
Update scrape.py for deprecated random.shuffle args

### DIFF
--- a/fitsnap3lib/scrapers/scrape.py
+++ b/fitsnap3lib/scrapers/scrape.py
@@ -127,7 +127,7 @@ class Scraper:
                     self.files[folder] = []
                 self.files[folder].append([folder + '/' + file_name, int(stat(folder + '/' + file_name).st_size)])
             if self.config.sections["GROUPS"].random_sampling:
-                shuffle(self.files[folder], random)
+                shuffle(self.files[folder])
 
             # TODO: potentially rework "training_size" and "testing_size" variables to be consistent with user input
             # NOTE for future: In FitSNAP input files, training_size and testing_size are floats between 0.0 and 1.0. Below, they get turned into integers. Was fine before, now inconsistent in API mode when accessing these vars from group_table (esp. b/c their group_types are still "float"). Prob best to refactor training_size/testing_size ints from here forward to "ntraining"/"ntesting" or similar.


### PR DESCRIPTION
Adding 'random' object to seed random.shuffle now deprecated, see e.g. https://bugs.python.org/issue44272.
Tested with Python 3.11.6.
Changing this should not be an issue because this argument has been deprecated (with warning) from Python 3.9 and we currently require Python 3.10+.