### PR TITLE
Reduce memory overhead for large parallel ACE and minor label fix for ACE coefficient output

### DIFF
--- a/fitsnap3lib/io/outputs/pace.py
+++ b/fitsnap3lib/io/outputs/pace.py
@@ -192,10 +192,11 @@ def _to_coeff_string(coeffs, config):
     desc_str = "ACE"
     coeffs = coeffs.reshape((config.sections[desc_str].numtypes, -1))
     blank2Js = config.sections[desc_str].blank2J.reshape((config.sections[desc_str].numtypes, -1))
-    #if config.sections[desc_str].bzeroflag:
-    #    blank2Js = np.insert(blank2Js, 0, [1.0], axis=1)
+    if config.sections[desc_str].bzeroflag:
+        coeff_names = config.sections[desc_str].blist
+    else:
+        coeff_names = [[0]]+config.sections[desc_str].blist
     coeffs = np.multiply(coeffs, blank2Js)
-    coeff_names = [[0]]+config.sections[desc_str].blist
     type_names = config.sections[desc_str].types
     out = f"# FitSNAP generated on {datetime.now()} with Hash: {config.hash}\n\n"
     out += "{} {}\n".format(len(type_names), int(np.ceil(len(coeff_names)/config.sections[desc_str].numtypes)))

--- a/fitsnap3lib/io/sections/calculator_sections/ace.py
+++ b/fitsnap3lib/io/sections/calculator_sections/ace.py
@@ -132,57 +132,61 @@ try:
                 self.blank2J = np.reshape(self.blank2J, (len(self.blist) + self.numtypes))
             else:
                 self.blank2J = np.reshape(self.blank2J, len(self.blist))
-
+        
         def _write_couple(self):
-            if self.bzeroflag:
-                assert len(self.types) ==  len(self.erefs), "must provide reference energy for each atom type"
-                reference_ens = [float(e0) for e0 in self.erefs]
-            elif not self.bzeroflag:
-                reference_ens = [0.0] * len(self.types)
-            bondinds=range(len(self.types))
-            bonds = [b for b in itertools.product(bondinds,bondinds)]
-            bondstrs = ['[%d, %d]' % b for b in bonds]
-            assert len(self.lmbda) == len(bondstrs), "must provide rc, lambda, for each BOND type" 
-            assert len(self.rcutfac) == len(bondstrs), "must provide rc, lambda, for each BOND type" 
-            if len(self.lmbda) == 1:
-                lmbdavals = self.lmbda
-                rcvals = self.rcutfac
-                rcinnervals = self.rcinner
-                drcinnervals = self.drcinner
-            if len(self.lmbda) > 1:
-                lmbdavals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.lmbda)}
-                rcvals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.rcutfac)}
-                rcinnervals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.rcinner)}
-                drcinnervals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.drcinner)}
+            @self.pt.sub_rank_zero
+            def decorated_write_couple():
+                if self.bzeroflag:
+                    assert len(self.types) ==  len(self.erefs), "must provide reference energy for each atom type"
+                    reference_ens = [float(e0) for e0 in self.erefs]
+                elif not self.bzeroflag:
+                    reference_ens = [0.0] * len(self.types)
+                bondinds=range(len(self.types))
+                bonds = [b for b in itertools.product(bondinds,bondinds)]
+                bondstrs = ['[%d, %d]' % b for b in bonds]
+                assert len(self.lmbda) == len(bondstrs), "must provide rc, lambda, for each BOND type" 
+                assert len(self.rcutfac) == len(bondstrs), "must provide rc, lambda, for each BOND type" 
+                if len(self.lmbda) == 1:
+                    lmbdavals = self.lmbda
+                    rcvals = self.rcutfac
+                    rcinnervals = self.rcinner
+                    drcinnervals = self.drcinner
+                if len(self.lmbda) > 1:
+                    lmbdavals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.lmbda)}
+                    rcvals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.rcutfac)}
+                    rcinnervals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.rcinner)}
+                    drcinnervals = {bondstr:lmb for bondstr,lmb in zip(bondstrs,self.drcinner)}
 
-            ldict = {int(rank):int(lmax) for rank,lmax in zip(self.ranks,self.lmax)}
-            L_R = 0 
-            M_R = 0
-            rankstrlst = ['%s']*len(self.ranks)
-            rankstr = ''.join(rankstrlst) % tuple(self.ranks)
-            lstrlst = ['%s']*len(self.ranks)
-            lstr = ''.join(lstrlst) % tuple(self.lmax)
-            if not self.wigner_flag:
-                try:
-                    with open('cg_LR_%d_r%s_lmax%s.pickle' %(L_R,rankstr,lstr),'rb') as handle:
-                        ccs = pickle.load(handle)
-                except FileNotFoundError:
-                    ccs = get_cg_coupling(ldict,L_R=L_R)
-                    #print (ccs)
-                    #store them for later so they don't need to be recalculated
-                    store_generalized(ccs, coupling_type='cg',L_R=L_R)
-            else:
-                try:
-                    with open('wig_LR_%d_r%s_lmax%s.pickle' %(L_R,rankstr,lstr),'rb') as handle:
-                        ccs = pickle.load(handle)
-                except FileNotFoundError:
-                    ccs = get_wig_coupling(ldict,L_R)
-                    #print (ccs)
-                    #store them for later so they don't need to be recalculated
-                    store_generalized(ccs, coupling_type='wig',L_R=L_R)
+                ldict = {int(rank):int(lmax) for rank,lmax in zip(self.ranks,self.lmax)}
+                L_R = 0 
+                M_R = 0
+                rankstrlst = ['%s']*len(self.ranks)
+                rankstr = ''.join(rankstrlst) % tuple(self.ranks)
+                lstrlst = ['%s']*len(self.ranks)
+                lstr = ''.join(lstrlst) % tuple(self.lmax)
+                if not self.wigner_flag:
+                    try:
+                        with open('cg_LR_%d_r%s_lmax%s.pickle' %(L_R,rankstr,lstr),'rb') as handle:
+                            ccs = pickle.load(handle)
+                    except FileNotFoundError:
+                        ccs = get_cg_coupling(ldict,L_R=L_R)
+                        #print (ccs)
+                        #store them for later so they don't need to be recalculated
+                        store_generalized(ccs, coupling_type='cg',L_R=L_R)
+                else:
+                    try:
+                        with open('wig_LR_%d_r%s_lmax%s.pickle' %(L_R,rankstr,lstr),'rb') as handle:
+                            ccs = pickle.load(handle)
+                    except FileNotFoundError:
+                        ccs = get_wig_coupling(ldict,L_R)
+                        #print (ccs)
+                        #store them for later so they don't need to be recalculated
+                        store_generalized(ccs, coupling_type='wig',L_R=L_R)
 
-            apot = AcePot(self.types, reference_ens, [int(k) for k in self.ranks], [int(k) for k in self.nmax],  [int(k) for k in self.lmax], self.nmaxbase, rcvals, lmbdavals, rcinnervals, drcinnervals, [int(k) for k in self.lmin], self.b_basis, **{'ccs':ccs[M_R]})
-            apot.write_pot('coupling_coefficients')
+                apot = AcePot(self.types, reference_ens, [int(k) for k in self.ranks], [int(k) for k in self.nmax],  [int(k) for k in self.lmax], self.nmaxbase, rcvals, lmbdavals, rcinnervals, drcinnervals, [int(k) for k in self.lmin], self.b_basis, **{'ccs':ccs[M_R]})
+                apot.write_pot('coupling_coefficients')
+
+            decorated_write_couple()
 
 except ModuleNotFoundError:
 

--- a/fitsnap3lib/lib/sym_ACE/clebsch_tree.py
+++ b/fitsnap3lib/lib/sym_ACE/clebsch_tree.py
@@ -1,163 +1,175 @@
 from fitsnap3lib.lib.sym_ACE.gen_labels import *
 from fitsnap3lib.lib.sym_ACE.coupling_coeffs import *
+from mpi4py import MPI
 
+comm = MPI.COMM_WORLD
+
+from fitsnap3lib.parallel_tools import ParallelTools
+pt = ParallelTools(comm = comm)
+
+
+@pt.rank_zero
 def get_ms(l,M_R=0):
 
-	# retrieves the set of m_i combinations obeying \sum_i m_i = M_R for an arbitrary l vector
-	m_ranges={ind:range(-l[ind],l[ind]+1) for ind in range(len(l))}
-	m_range_arrays = [list(m_ranges[ind]) for ind in range(len(l))]
-	m_combos = list(itertools.product(*m_range_arrays))
-	first_m_filter = [i for i in m_combos if np.sum(i) == M_R]
-	m_list_replace = ['%d']*len(l)
-	m_str_variable = ','.join(b for b in m_list_replace)
-	m_strs = [ m_str_variable % fmf for fmf in first_m_filter]
-	return m_strs
+    # retrieves the set of m_i combinations obeying \sum_i m_i = M_R for an arbitrary l vector
+    m_ranges={ind:range(-l[ind],l[ind]+1) for ind in range(len(l))}
+    m_range_arrays = [list(m_ranges[ind]) for ind in range(len(l))]
+    m_combos = list(itertools.product(*m_range_arrays))
+    first_m_filter = [i for i in m_combos if np.sum(i) == M_R]
+    m_list_replace = ['%d']*len(l)
+    m_str_variable = ','.join(b for b in m_list_replace)
+    m_strs = [ m_str_variable % fmf for fmf in first_m_filter]
+    return m_strs
 
 #manually coded reductions of spherical harmonics 
+@pt.rank_zero
 def rank_1_cg_tree(l,L_R=0,M_R=0):
 
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = [()]
-	assert l[0] == L_R, "invalid l=%d for irrep L_R = %d" % (l[0],L_R)
-	
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = [()]
+    assert l[0] == L_R, "invalid l=%d for irrep L_R = %d" % (l[0],L_R)
+    
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			# m_1  = - M_R
-			conds= m_ints[0]  ==  M_R
-			if conds:
-				w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],L_R,M_R,0,0)]
-				phase = 1 
-				w = phase * w1
+    for inter in full_inter_tuples:
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            # m_1  = - M_R
+            conds= m_ints[0]  ==  M_R
+            if conds:
+                w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],L_R,M_R,0,0)]
+                phase = 1 
+                w = phase * w1
 
-				decomposed[inter][mstr] = w
-	return decomposed
+                decomposed[inter][mstr] = w
+    return decomposed
 
 
+@pt.rank_zero
 def rank_2_cg_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	node = nodes[0]
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = [()]
+    nodes,remainder = tree(l)
+    node = nodes[0]
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = [()]
 
-	assert check_triangle(l[0],l[1],L_R) , "invalid l=(%d,%d) for irrep L_R = %d" % (l[0],l[1],L_R)
+    assert check_triangle(l[0],l[1],L_R) , "invalid l=(%d,%d) for irrep L_R = %d" % (l[0],l[1],L_R)
 
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			# m_1 + m_2 = M1
-			conds= (m_ints[0] + m_ints[1]) == M_R
-			if conds:
-				w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L_R,M_R)]
-				phase = 1
-				w = phase * w1 
+    for inter in full_inter_tuples:
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            # m_1 + m_2 = M1
+            conds= (m_ints[0] + m_ints[1]) == M_R
+            if conds:
+                w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L_R,M_R)]
+                phase = 1
+                w = phase * w1 
 
-				decomposed[inter][mstr] = (w)
-	return decomposed
+                decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_3_cg_tree(l,L_R=0,M_R=0):
 
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	mstrs = get_ms(l,M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    mstrs = get_ms(l,M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 = inter[0]
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				# m_1 + m_2 = M1
-				# M1 + m_3 = M_R
-				conds= (m_ints[0] + m_ints[1]) == M1 and\
-				(M1+m_ints[2]) == M_R
-				if conds:
-					w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
-					w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,l[2],m_ints[2],L_R,M_R)]
-					phase = 1
-					w = phase * w1 * w2
-					decomposed[inter][mstr] = (w)
-	return decomposed
+    for inter in full_inter_tuples:
+        L1 = inter[0]
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                # m_1 + m_2 = M1
+                # M1 + m_3 = M_R
+                conds= (m_ints[0] + m_ints[1]) == M1 and\
+                (M1+m_ints[2]) == M_R
+                if conds:
+                    w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
+                    w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,l[2],m_ints[2],L_R,M_R)]
+                    phase = 1
+                    w = phase * w1 * w2
+                    decomposed[inter][mstr] = (w)
+    return decomposed
 
 
+@pt.rank_zero
 def generalized_rank_4_inters(grouped_l,L_R):
-	l = flatten(grouped_l)
-	l1,l2,l3,l4 = tuple(l)
-	size_by_orbit = { io: len(o) for io,o in enumerate(grouped_l) }
-	pairs = [p for p in grouped_l if len(p) ==2]
-	singles =[ p for p in grouped_l if len(p) < 2]
-	assert len(pairs + singles) == len(grouped_l), "bad orbit size for intermediate vector"
+    l = flatten(grouped_l)
+    l1,l2,l3,l4 = tuple(l)
+    size_by_orbit = { io: len(o) for io,o in enumerate(grouped_l) }
+    pairs = [p for p in grouped_l if len(p) ==2]
+    singles =[ p for p in grouped_l if len(p) < 2]
+    assert len(pairs + singles) == len(grouped_l), "bad orbit size for intermediate vector"
 
-	base_inters = {}
-	valid_inters = []
-	mstrs = []
-	for io,o in enumerate(grouped_l):
-		if size_by_orbit[io] == 2:
-			base_inters[io] = [Lk for Lk in get_intermediates_w(o[0],o[1])  if np.sum(o + (Lk,)) % 2 ==0 ] 
-	if len(base_inters.keys()) == 2:
-		inters_set = [ (bi1,bi2) for bi1,bi2 in itertools.product( base_inters[0] , base_inters[1]) if check_triangle(bi1,bi2,L_R)]
-		valid_inters.extend(inters_set)
-	elif len(base_inters.keys()) == 1:
-		size_2 = list(base_inters.keys())[0]
-		for inter1 in base_inters[size_2]:
-			
-			inters_next = [ i for i in get_intermediates_w(inter1, grouped_l[1][0]) if check_triangle(grouped_l[2][0],i,L_R)]
-			current_valids = [(inter1,inxt) for inxt in inters_next]
-			valid_inters.extend(current_valids)
-	"""
-	for inter in valid_inters:
-		o1 = grouped_l[0]
-		o2 = grouped_l[1]
-		o1prd = itertools.product(range(-o1[0],o1[0]+1),range(-o1[1],o1[1]+1))
-		o2prd = itertools.product(range(-o2[0],o2[0]+1),range(-o2[1],o2[1]+1))
-		for Mo1 in range(-inter[0],inter[0]+1):
-			mo1s = [ (mi,mj) for (mi,mj) in o1prd if np.sum((mi,mj)) == Mo1 ] 
-	"""
-	return valid_inters
-		
+    base_inters = {}
+    valid_inters = []
+    mstrs = []
+    for io,o in enumerate(grouped_l):
+        if size_by_orbit[io] == 2:
+            base_inters[io] = [Lk for Lk in get_intermediates_w(o[0],o[1])  if np.sum(o + (Lk,)) % 2 ==0 ] 
+    if len(base_inters.keys()) == 2:
+        inters_set = [ (bi1,bi2) for bi1,bi2 in itertools.product( base_inters[0] , base_inters[1]) if check_triangle(bi1,bi2,L_R)]
+        valid_inters.extend(inters_set)
+    elif len(base_inters.keys()) == 1:
+        size_2 = list(base_inters.keys())[0]
+        for inter1 in base_inters[size_2]:
+            
+            inters_next = [ i for i in get_intermediates_w(inter1, grouped_l[1][0]) if check_triangle(grouped_l[2][0],i,L_R)]
+            current_valids = [(inter1,inxt) for inxt in inters_next]
+            valid_inters.extend(current_valids)
+    """
+    for inter in valid_inters:
+        o1 = grouped_l[0]
+        o2 = grouped_l[1]
+        o1prd = itertools.product(range(-o1[0],o1[0]+1),range(-o1[1],o1[1]+1))
+        o2prd = itertools.product(range(-o2[0],o2[0]+1),range(-o2[1],o2[1]+1))
+        for Mo1 in range(-inter[0],inter[0]+1):
+            mo1s = [ (mi,mj) for (mi,mj) in o1prd if np.sum((mi,mj)) == Mo1 ] 
+    """
+    return valid_inters
+        
 """
 def generalized_rank_4_cg_tree(l,sigma_c,L_R=0,M_R=0):
-	print ('NOTE the m vectors in this loop are only generalized for COMPLETELY degenerate l_i')
-	grouped_l = group_vec_by_orbits(l,sigma_c)
+    print ('NOTE the m vectors in this loop are only generalized for COMPLETELY degenerate l_i')
+    grouped_l = group_vec_by_orbits(l,sigma_c)
 
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = generalized_rank_4_inters(grouped_l,L_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = generalized_rank_4_inters(grouped_l,L_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1,L2 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				for M2 in range(-L2,L2+1):
-					conds_per_couple_typ = { (2,2): (m_ints[0] + m_ints[1]) == M1 and\
-									(m_ints[2] + m_ints[3]) == M2 and\
-									(M1+M2) == M_R,
-							       (2,1,1): (m_ints[0] + m_ints[1]) == M1 and\
-									(m_ints[2] + M1) == M2 and\
-									(m_ints[3] + M2) == M_R
-								}
-					conds = conds_per_couple_typ[sigma_c]
-					if conds:
-						if sigma_c == (2,2):
-							w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
-							w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,M2)]
-							w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L_R,M_R)]
-							phase = 1
-							w = phase * w1 * w2 * w3
-							decomposed[inter][mstr] = (w)
-						elif sigma_c == (2,1,1):
-							w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
-							w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,l[2],m_ints[2],L2,M2)]
-							w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L2,M2,l[3],m_ints[3],L_R,M_R)]
-							phase = 1
-							w = phase * w1 * w2 * w3
-							decomposed[inter][mstr] = (w)
-	return decomposed	
+    for inter in full_inter_tuples:
+        L1,L2 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                for M2 in range(-L2,L2+1):
+                    conds_per_couple_typ = { (2,2): (m_ints[0] + m_ints[1]) == M1 and\
+                                    (m_ints[2] + m_ints[3]) == M2 and\
+                                    (M1+M2) == M_R,
+                                   (2,1,1): (m_ints[0] + m_ints[1]) == M1 and\
+                                    (m_ints[2] + M1) == M2 and\
+                                    (m_ints[3] + M2) == M_R
+                                }
+                    conds = conds_per_couple_typ[sigma_c]
+                    if conds:
+                        if sigma_c == (2,2):
+                            w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
+                            w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,M2)]
+                            w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L_R,M_R)]
+                            phase = 1
+                            w = phase * w1 * w2 * w3
+                            decomposed[inter][mstr] = (w)
+                        elif sigma_c == (2,1,1):
+                            w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
+                            w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,l[2],m_ints[2],L2,M2)]
+                            w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L2,M2,l[3],m_ints[3],L_R,M_R)]
+                            phase = 1
+                            w = phase * w1 * w2 * w3
+                            decomposed[inter][mstr] = (w)
+    return decomposed    
 
 ltst = [1,1,1,1]
 #sigmactst = (2,1,1)
@@ -166,188 +178,195 @@ these_cgs = generalized_rank_4_cg_tree(l=ltst,sigma_c=sigmactst,L_R=0,M_R=0)
 
 print (these_cgs)
 """
+@pt.rank_zero
 def rank_4_cg_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1,L2 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				for M2 in range(-L2,L2+1):
-					# m_1 + m_2 = M1
-					# m_4 + m_3 = M2
-					# M1 + M2 = M_R
-					conds= (m_ints[0] + m_ints[1]) == M1 and\
-					(m_ints[2] + m_ints[3]) == M2 and\
-					(M1+M2) == M_R
-					if conds:
-						w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
-						w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,M2)]
-						w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L_R,M_R)]
-						#phase_power = ( L1 + L2 ) - ( M1 + M2 )  + ( L_R - M_R)
-						#phase = (-1) ** phase_power
-						phase = 1
-						w = phase * w1 * w2 * w3 
+    for inter in full_inter_tuples:
+        L1,L2 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                for M2 in range(-L2,L2+1):
+                    # m_1 + m_2 = M1
+                    # m_4 + m_3 = M2
+                    # M1 + M2 = M_R
+                    conds= (m_ints[0] + m_ints[1]) == M1 and\
+                    (m_ints[2] + m_ints[3]) == M2 and\
+                    (M1+M2) == M_R
+                    if conds:
+                        w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
+                        w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,M2)]
+                        w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L_R,M_R)]
+                        #phase_power = ( L1 + L2 ) - ( M1 + M2 )  + ( L_R - M_R)
+                        #phase = (-1) ** phase_power
+                        phase = 1
+                        w = phase * w1 * w2 * w3 
 
-						decomposed[inter][mstr] = (w)
-	return decomposed
+                        decomposed[inter][mstr] = (w)
+    return decomposed
 
 
 
+@pt.rank_zero
 def rank_5_cg_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1,L2,L3 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				for M2 in range(-L2,L2+1):
-					for M3 in range(-L3,L3+1):
-						# m_1 + m_2 = M1
-						# m_4 + m_3 = M2
-						# M1 + M2 = M3
-						conds= (m_ints[0] + m_ints[1]) == M1 and\
-						(m_ints[2] + m_ints[3]) == M2 and\
-						(M1+M2) == M3 and\
-						(M3+m_ints[4]) == M_R
-						if conds:
-							w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
-							w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,M2)]
-							w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L3,M3)]
-							w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3,M3,l[4],m_ints[4],L_R,M_R)]
-							phase = 1
-							w = phase * w1 * w2 * w3 * w4
+    for inter in full_inter_tuples:
+        L1,L2,L3 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                for M2 in range(-L2,L2+1):
+                    for M3 in range(-L3,L3+1):
+                        # m_1 + m_2 = M1
+                        # m_4 + m_3 = M2
+                        # M1 + M2 = M3
+                        conds= (m_ints[0] + m_ints[1]) == M1 and\
+                        (m_ints[2] + m_ints[3]) == M2 and\
+                        (M1+M2) == M3 and\
+                        (M3+m_ints[4]) == M_R
+                        if conds:
+                            w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,M1)]
+                            w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,M2)]
+                            w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L3,M3)]
+                            w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3,M3,l[4],m_ints[4],L_R,M_R)]
+                            phase = 1
+                            w = phase * w1 * w2 * w3 * w4
 
-							decomposed[inter][mstr] = (w)
-	return decomposed
+                            decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_6_cg_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 , L2 , L3 , L4 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1 , L1 + 1):
-				for M2 in range(-L2 , L2 + 1 ):
-					for M3 in range(-L3 , L3 + 1):
-						for M4 in range(-L4 , L4 + 1):
-							# m_1 + m_2 = M1
-							# m_4 + m_3 = M2
-							# m_5 + m_6 = M3
-							# M1 + M2 = M4
-							# M3 + M4 = M_R
-							conds= (m_ints[0] + m_ints[1]) == M1 and\
-							(m_ints[2] + m_ints[3]) == M2 and\
-							(m_ints[4] + m_ints[5]) == M3 and\
-							( M1 + M2 ) == M4 and\
-							( M3 + M4 ) == M_R
-							if conds:
-								w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , M1)]
-								w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , M2)]
-								w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , M3)]
-								w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , M4)]
-								w5 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L_R , M_R)]
-								phase = 1
-								w = phase * w1 * w2 * w3 * w4 * w5
+    for inter in full_inter_tuples:
+        L1 , L2 , L3 , L4 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1 , L1 + 1):
+                for M2 in range(-L2 , L2 + 1 ):
+                    for M3 in range(-L3 , L3 + 1):
+                        for M4 in range(-L4 , L4 + 1):
+                            # m_1 + m_2 = M1
+                            # m_4 + m_3 = M2
+                            # m_5 + m_6 = M3
+                            # M1 + M2 = M4
+                            # M3 + M4 = M_R
+                            conds= (m_ints[0] + m_ints[1]) == M1 and\
+                            (m_ints[2] + m_ints[3]) == M2 and\
+                            (m_ints[4] + m_ints[5]) == M3 and\
+                            ( M1 + M2 ) == M4 and\
+                            ( M3 + M4 ) == M_R
+                            if conds:
+                                w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , M1)]
+                                w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , M2)]
+                                w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , M3)]
+                                w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , M4)]
+                                w5 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L_R , M_R)]
+                                phase = 1
+                                w = phase * w1 * w2 * w3 * w4 * w5
 
-								decomposed[inter][mstr] = (w)
-	return decomposed
+                                decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_7_cg_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 , L2 , L3 , L4 , L5 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1 , L1 + 1):
-				for M2 in range(-L2 , L2 + 1 ):
-					for M3 in range(-L3 , L3 + 1):
-						for M4 in range(-L4 , L4 + 1):
-							for M5 in range(-L5 , L5 + 1):
-								# m_1 + m_2 = M1
-								# m_4 + m_3 = M2
-								# m_5 + m_6 = M3
-								# M1 + M2 = M4
-								# M3 + m_7 = M5
-								# M3 + M4 = M_R
-								conds= (m_ints[0] + m_ints[1]) == M1 and\
-								(m_ints[2] + m_ints[3]) == M2 and\
-								(m_ints[4] + m_ints[5]) == M3 and\
-								( M1 + M2 ) == M4 and\
-								( M3 + m_ints[6]) == M5 and\
-								( M4 + M5 ) == M_R
-								if conds:
-									w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , M1)]
-									w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , M2)]
-									w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , M3)]
-									w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , M4)]
-									w5 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3 , M3 , l[6] , m_ints[6] , L5 , M5)]
-									w6 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L4 , M4 , L5 , M5 , L_R , M_R)]
-									phase = 1
-									w = phase * w1 * w2 * w3 * w4 * w5 * w6
+    for inter in full_inter_tuples:
+        L1 , L2 , L3 , L4 , L5 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1 , L1 + 1):
+                for M2 in range(-L2 , L2 + 1 ):
+                    for M3 in range(-L3 , L3 + 1):
+                        for M4 in range(-L4 , L4 + 1):
+                            for M5 in range(-L5 , L5 + 1):
+                                # m_1 + m_2 = M1
+                                # m_4 + m_3 = M2
+                                # m_5 + m_6 = M3
+                                # M1 + M2 = M4
+                                # M3 + m_7 = M5
+                                # M3 + M4 = M_R
+                                conds= (m_ints[0] + m_ints[1]) == M1 and\
+                                (m_ints[2] + m_ints[3]) == M2 and\
+                                (m_ints[4] + m_ints[5]) == M3 and\
+                                ( M1 + M2 ) == M4 and\
+                                ( M3 + m_ints[6]) == M5 and\
+                                ( M4 + M5 ) == M_R
+                                if conds:
+                                    w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , M1)]
+                                    w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , M2)]
+                                    w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , M3)]
+                                    w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , M4)]
+                                    w5 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3 , M3 , l[6] , m_ints[6] , L5 , M5)]
+                                    w6 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L4 , M4 , L5 , M5 , L_R , M_R)]
+                                    phase = 1
+                                    w = phase * w1 * w2 * w3 * w4 * w5 * w6
 
-									decomposed[inter][mstr] = (w)
-	return decomposed
+                                    decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_8_cg_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 , L2 , L3 , L4 , L5 , L6 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1 , L1 + 1):
-				for M2 in range(-L2 , L2 + 1 ):
-					for M3 in range(-L3 , L3 + 1):
-						for M4 in range(-L4 , L4 + 1):
-							for M5 in range(-L5 , L5 + 1):
-								for M5 in range(-L6 , L6 + 1):
-									# m_1 + m_2 = M1
-									# m_4 + m_3 = M2
-									# m_5 + m_6 = M3
-									# M1 + M2 = M5
-									# M3 + M4 = M6
-									# M5 + M6 = M_R
-									conds= (m_ints[0] + m_ints[1]) == M1 and\
-									(m_ints[2] + m_ints[3]) == M2 and\
-									(m_ints[4] + m_ints[5]) == M3 and\
-									( M1 + M2 ) == M5 and\
-									( M3 + M4) == M6 and\
-									( M5 + M6 ) == M_R
-									if conds:
-										w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , M1)]
-										w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , M2)]
-										w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , M3)]
-										w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[6] , m_ints[6] , l[7] , m_ints[7] , L4 , M4)]
-										w5 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L5 , M5)]
-										w6 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L6 , M6)]
-										w7 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L5 , M5 , L6 , M6 , L_R , M_R)]
-										phase = 1
-										w = phase * w1 * w2 * w3 * w4 * w5 * w6 * w7
+    for inter in full_inter_tuples:
+        L1 , L2 , L3 , L4 , L5 , L6 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1 , L1 + 1):
+                for M2 in range(-L2 , L2 + 1 ):
+                    for M3 in range(-L3 , L3 + 1):
+                        for M4 in range(-L4 , L4 + 1):
+                            for M5 in range(-L5 , L5 + 1):
+                                for M5 in range(-L6 , L6 + 1):
+                                    # m_1 + m_2 = M1
+                                    # m_4 + m_3 = M2
+                                    # m_5 + m_6 = M3
+                                    # M1 + M2 = M5
+                                    # M3 + M4 = M6
+                                    # M5 + M6 = M_R
+                                    conds= (m_ints[0] + m_ints[1]) == M1 and\
+                                    (m_ints[2] + m_ints[3]) == M2 and\
+                                    (m_ints[4] + m_ints[5]) == M3 and\
+                                    ( M1 + M2 ) == M5 and\
+                                    ( M3 + M4) == M6 and\
+                                    ( M5 + M6 ) == M_R
+                                    if conds:
+                                        w1 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , M1)]
+                                        w2 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , M2)]
+                                        w3 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , M3)]
+                                        w4 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(l[6] , m_ints[6] , l[7] , m_ints[7] , L4 , M4)]
+                                        w5 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L5 , M5)]
+                                        w6 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L6 , M6)]
+                                        w7 = Clebsch_Gordan['%d,%d,%d,%d,%d,%d' %(L5 , M5 , L6 , M6 , L_R , M_R)]
+                                        phase = 1
+                                        w = phase * w1 * w2 * w3 * w4 * w5 * w6 * w7
 
-										decomposed[inter][mstr] = w
-	return decomposed
+                                        decomposed[inter][mstr] = w
+    return decomposed
+
+del pt

--- a/fitsnap3lib/lib/sym_ACE/coupling_coeffs.py
+++ b/fitsnap3lib/lib/sym_ACE/coupling_coeffs.py
@@ -4,9 +4,14 @@ import pickle
 import numpy as np
 import os
 
+from mpi4py import MPI
 
-#lib_path = os.getcwd()
+comm = MPI.COMM_WORLD
 
+from fitsnap3lib.parallel_tools import ParallelTools
+pt = ParallelTools(comm = comm)
+
+@pt.rank_zero
 def Clebsch_gordan(j1,m1,j2,m2,j3,m3):
     # Clebsch-gordan coefficient calculator based on eqs. 4-5 of:
     # https://hal.inria.fr/hal-01851097/document
@@ -61,6 +66,7 @@ def Clebsch_gordan(j1,m1,j2,m2,j3,m3):
     else:
         return 0.
 
+@pt.rank_zero
 def clebsch_gordan(l1,m1,l2,m2,l3,m3):
     # try to load c library for calculating cg coefficients
     #if cglib:
@@ -68,6 +74,7 @@ def clebsch_gordan(l1,m1,l2,m2,l3,m3):
     #else:
     return Clebsch_gordan(l1,m1,l2,m2,l3,m3)
 
+@pt.rank_zero
 def wigner_3j(j1,m1,j2,m2,j3,m3):
     # uses relation between Clebsch-Gordann coefficients and W-3j symbols to evaluate W-3j
     #VERIFIED - wolframalpha.com
@@ -79,6 +86,7 @@ def wigner_3j(j1,m1,j2,m2,j3,m3):
     return cg* float(num/denom)
 
 
+@pt.rank_zero
 def init_clebsch_gordan(lmax):
     #returns dictionary of all cg coefficients to be used at a given value of lmax
     cg = {}
@@ -93,6 +101,7 @@ def init_clebsch_gordan(lmax):
     return cg
 
 
+@pt.rank_zero
 def init_wigner_3j(lmax):
     #returns dictionary of all cg coefficients to be used at a given value of lmax
     cg = {}
@@ -106,6 +115,7 @@ def init_wigner_3j(lmax):
                             cg[key] = wigner_3j(l1,m1,l2,m2,l3,m3)
     return cg
 
+@pt.rank_zero
 def store_generalized(coupling_dct,coupling_type,L_R):
     M_Rs = list(coupling_dct.keys())
     ranks = tuple(list(coupling_dct[M_Rs[0]].keys()))
@@ -129,22 +139,27 @@ def store_generalized(coupling_dct,coupling_type,L_R):
     with open(file_name, 'wb') as handle:
         pickle.dump(coupling_dct, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
-# store a large dictionary of clebsch gordan coefficients
-try:
-    with open('%s/Clebsch_Gordan.pickle' %lib_path, 'rb') as handle:
-        Clebsch_Gordan = pickle.load(handle)
-except FileNotFoundError:
-    print ("Generating your first pickled library of CG coefficients. This will take a few moments...")
-    Clebsch_Gordan = init_clebsch_gordan(lmax_traditional)
-    with open('%s/Clebsch_Gordan.pickle' %lib_path, 'wb') as handle:
-        pickle.dump(Clebsch_Gordan, handle, protocol=pickle.HIGHEST_PROTOCOL)
-# do the same thing for the traditional wigner_3j symbols
-try:
-    with open('%s/Wigner_3j.pickle' % lib_path, 'rb') as handle:
-        Wigner_3j = pickle.load(handle)
-except FileNotFoundError:
-    print ("Generating your first pickled library of Wigner 3j coefficients. This will take a few moments...")
-    Wigner_3j = init_wigner_3j(lmax_traditional)
-    with open('%s/Wigner_3j.pickle' % lib_path, 'wb') as handle:
-        pickle.dump(Wigner_3j, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
+# Only build cg pickle on rank 0 and only load on rank 0 to save memory
+if pt.get_rank() == 0:
+    # store a large dictionary of clebsch gordan coefficients
+    try:
+        with open('%s/Clebsch_Gordan.pickle' %lib_path, 'rb') as handle:
+            Clebsch_Gordan = pickle.load(handle)
+    except FileNotFoundError:
+        print ("Generating your first pickled library of CG coefficients. This will take a few moments...")
+        Clebsch_Gordan = init_clebsch_gordan(lmax_traditional)
+        with open('%s/Clebsch_Gordan.pickle' %lib_path, 'wb') as handle:
+            pickle.dump(Clebsch_Gordan, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    # do the same thing for the traditional wigner_3j symbols
+    try:
+        with open('%s/Wigner_3j.pickle' % lib_path, 'rb') as handle:
+            Wigner_3j = pickle.load(handle)
+    except FileNotFoundError:
+        print ("Generating your first pickled library of Wigner 3j coefficients. This will take a few moments...")
+        Wigner_3j = init_wigner_3j(lmax_traditional)
+        with open('%s/Wigner_3j.pickle' % lib_path, 'wb') as handle:
+            pickle.dump(Wigner_3j, handle, protocol=pickle.HIGHEST_PROTOCOL)
+
+# get rid of local ParallelTools object.
+del pt

--- a/fitsnap3lib/lib/sym_ACE/wigner_tree.py
+++ b/fitsnap3lib/lib/sym_ACE/wigner_tree.py
@@ -1,126 +1,138 @@
 from fitsnap3lib.lib.sym_ACE.gen_labels import *
 from fitsnap3lib.lib.sym_ACE.coupling_coeffs import *
+from mpi4py import MPI
+
+comm = MPI.COMM_WORLD
+
+from fitsnap3lib.parallel_tools import ParallelTools
+pt = ParallelTools(comm = comm)
 
 #library to generate generalized Wigner symbols using sigma_c symmetric (full ordered) 
 #  binary trees.
 
+@pt.rank_zero
 def get_ms(l,M_R=0):
 
-	# retrieves the set of m_i combinations obeying \sum_i m_i = M_R for an arbitrary l vector
-	m_ranges={ind:range(-l[ind],l[ind]+1) for ind in range(len(l))}
-	m_range_arrays = [list(m_ranges[ind]) for ind in range(len(l))]
-	m_combos = list(itertools.product(*m_range_arrays))
-	first_m_filter = [i for i in m_combos if np.sum(i) == M_R]
-	m_list_replace = ['%d']*len(l)
-	m_str_variable = ','.join(b for b in m_list_replace)
-	m_strs = [ m_str_variable % fmf for fmf in first_m_filter]
-	return m_strs
+    # retrieves the set of m_i combinations obeying \sum_i m_i = M_R for an arbitrary l vector
+    m_ranges={ind:range(-l[ind],l[ind]+1) for ind in range(len(l))}
+    m_range_arrays = [list(m_ranges[ind]) for ind in range(len(l))]
+    m_combos = list(itertools.product(*m_range_arrays))
+    first_m_filter = [i for i in m_combos if np.sum(i) == M_R]
+    m_list_replace = ['%d']*len(l)
+    m_str_variable = ','.join(b for b in m_list_replace)
+    m_strs = [ m_str_variable % fmf for fmf in first_m_filter]
+    return m_strs
 
 #alternative to manually coded couplings
+@pt.rank_zero
 def rank_1_tree(l,L_R=0,M_R=0):
-	#no nodes for rank 1
+    #no nodes for rank 1
 
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = [()]
-	assert l[0] == L_R, "invalid l=%d for irrep L_R = %d" % (l[0],L_R)
-	
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = [()]
+    assert l[0] == L_R, "invalid l=%d for irrep L_R = %d" % (l[0],L_R)
+    
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			# m_1  = - M_R
-			conds= m_ints[0]  == - M_R
-			if conds:
-				w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],L_R,M_R,0,0)]
-				phase_power = 0
-				phase = (-1) ** phase_power
-				w = phase * w1
+    for inter in full_inter_tuples:
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            # m_1  = - M_R
+            conds= m_ints[0]  == - M_R
+            if conds:
+                w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],L_R,M_R,0,0)]
+                phase_power = 0
+                phase = (-1) ** phase_power
+                w = phase * w1
 
-				decomposed[inter][mstr] = float(w)
-	return decomposed
+                decomposed[inter][mstr] = float(w)
+    return decomposed
 
 
+@pt.rank_zero
 def rank_2_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	node = nodes[0]
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = [()]
+    nodes,remainder = tree(l)
+    node = nodes[0]
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = [()]
 
-	assert check_triangle(l[0],l[1],L_R) , "invalid l=(%d,%d) for irrep L_R = %d" % (l[0],l[1],L_R)
+    assert check_triangle(l[0],l[1],L_R) , "invalid l=(%d,%d) for irrep L_R = %d" % (l[0],l[1],L_R)
 
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			# m_1 + m_2 = M1
-			conds= (m_ints[0] + m_ints[1]) == M_R
-			if conds:
-				w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L_R,-M_R)]
-				phase_power = L_R - M_R
-				phase = (-1) ** phase_power
-				w = phase * w1 
+    for inter in full_inter_tuples:
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            # m_1 + m_2 = M1
+            conds= (m_ints[0] + m_ints[1]) == M_R
+            if conds:
+                w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L_R,-M_R)]
+                phase_power = L_R - M_R
+                phase = (-1) ** phase_power
+                w = phase * w1 
 
-				decomposed[inter][mstr] = (w)
-	return decomposed
+                decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_3_tree(l,L_R=0,M_R=0):
 
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	mstrs = get_ms(l,M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    mstrs = get_ms(l,M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 = inter[0]
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				# m_1 + m_2 = M1
-				# M1 + m_3 = M_R
-				conds= (m_ints[0] + m_ints[1]) == M1 and\
-				(M1+m_ints[2]) == M_R
-				if conds:
-					w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,-M1)]
-					w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1,M1,l[2],m_ints[2],L_R,-M_R)]
-					phase_power = ( L1 ) - ( M1  )  + ( L_R - M_R)
-					phase = (-1) ** phase_power
-					w = phase * w1 * w2
-					decomposed[inter][mstr] = (w)
-	return decomposed
-	
+    for inter in full_inter_tuples:
+        L1 = inter[0]
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                # m_1 + m_2 = M1
+                # M1 + m_3 = M_R
+                conds= (m_ints[0] + m_ints[1]) == M1 and\
+                (M1+m_ints[2]) == M_R
+                if conds:
+                    w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,-M1)]
+                    w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1,M1,l[2],m_ints[2],L_R,-M_R)]
+                    phase_power = ( L1 ) - ( M1  )  + ( L_R - M_R)
+                    phase = (-1) ** phase_power
+                    w = phase * w1 * w2
+                    decomposed[inter][mstr] = (w)
+    return decomposed
+    
 
+@pt.rank_zero
 def rank_4_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1,L2 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				for M2 in range(-L2,L2+1):
-					# m_1 + m_2 = M1
-					# m_4 + m_3 = M2
-					# M1 + M2 = M_R
-					conds= (m_ints[0] + m_ints[1]) == M1 and\
-					(m_ints[2] + m_ints[3]) == M2 and\
-					(M1+M2) == M_R
-					if conds:
-						w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,-M1)]
-						w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,-M2)]
-						w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L_R,-M_R)]
-						phase_power = ( L1 + L2 ) - ( M1 + M2 )  + ( L_R - M_R)
-						phase = (-1) ** phase_power
-						w = phase * w1 * w2 * w3 
+    for inter in full_inter_tuples:
+        L1,L2 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                for M2 in range(-L2,L2+1):
+                    # m_1 + m_2 = M1
+                    # m_4 + m_3 = M2
+                    # M1 + M2 = M_R
+                    conds= (m_ints[0] + m_ints[1]) == M1 and\
+                    (m_ints[2] + m_ints[3]) == M2 and\
+                    (M1+M2) == M_R
+                    if conds:
+                        w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,-M1)]
+                        w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,-M2)]
+                        w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L_R,-M_R)]
+                        phase_power = ( L1 + L2 ) - ( M1 + M2 )  + ( L_R - M_R)
+                        phase = (-1) ** phase_power
+                        w = phase * w1 * w2 * w3 
 
-						decomposed[inter][mstr] = w
-	return decomposed
+                        decomposed[inter][mstr] = w
+    return decomposed
 
+@pt.rank_zero
 def rank_4_recur_tree(l,L_R=0,M_R=0):
 
     inters = []
@@ -178,159 +190,165 @@ def rank_4_recur_tree(l,L_R=0,M_R=0):
     return decomposed
 
 
+@pt.rank_zero
 def rank_5_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1,L2,L3 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1,L1+1):
-				for M2 in range(-L2,L2+1):
-					for M3 in range(-L3,L3+1):
-						# m_1 + m_2 = M1
-						# m_4 + m_3 = M2
-						# M1 + M2 = M3
-						conds= (m_ints[0] + m_ints[1]) == M1 and\
-						(m_ints[2] + m_ints[3]) == M2 and\
-						(M1+M2) == M3 and\
-						(M3+m_ints[4]) == M_R
-						if conds:
-							w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,-M1)]
-							w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,-M2)]
-							w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L3,-M3)]
-							w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3,M3,l[4],m_ints[4],L_R,-M_R)]
-							phase_power = ( L1 + L2 + L3 ) - ( M1 + M2 + M3 )  + ( L_R - M_R)
-							phase = (-1) ** phase_power
-							w = phase * w1 * w2 * w3 * w4
+    for inter in full_inter_tuples:
+        L1,L2,L3 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1,L1+1):
+                for M2 in range(-L2,L2+1):
+                    for M3 in range(-L3,L3+1):
+                        # m_1 + m_2 = M1
+                        # m_4 + m_3 = M2
+                        # M1 + M2 = M3
+                        conds= (m_ints[0] + m_ints[1]) == M1 and\
+                        (m_ints[2] + m_ints[3]) == M2 and\
+                        (M1+M2) == M3 and\
+                        (M3+m_ints[4]) == M_R
+                        if conds:
+                            w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0],m_ints[0],l[1],m_ints[1],L1,-M1)]
+                            w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2],m_ints[2],l[3],m_ints[3],L2,-M2)]
+                            w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1,M1,L2,M2,L3,-M3)]
+                            w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3,M3,l[4],m_ints[4],L_R,-M_R)]
+                            phase_power = ( L1 + L2 + L3 ) - ( M1 + M2 + M3 )  + ( L_R - M_R)
+                            phase = (-1) ** phase_power
+                            w = phase * w1 * w2 * w3 * w4
 
-							decomposed[inter][mstr] = (w)
-	return decomposed
+                            decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_6_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 , L2 , L3 , L4 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1 , L1 + 1):
-				for M2 in range(-L2 , L2 + 1 ):
-					for M3 in range(-L3 , L3 + 1):
-						for M4 in range(-L4 , L4 + 1):
-							# m_1 + m_2 = M1
-							# m_4 + m_3 = M2
-							# m_5 + m_6 = M3
-							# M1 + M2 = M4
-							# M3 + M4 = M_R
-							conds= (m_ints[0] + m_ints[1]) == M1 and\
-							(m_ints[2] + m_ints[3]) == M2 and\
-							(m_ints[4] + m_ints[5]) == M3 and\
-							( M1 + M2 ) == M4 and\
-							( M3 + M4 ) == M_R
-							if conds:
-								w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , -M1)]
-								w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , -M2)]
-								w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , -M3)]
-								w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , -M4)]
-								w5 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L_R , -M_R)]
-								phase_power = ( L1 + L2 + L3 + L4 ) - ( M1 + M2 + M3 + M4 )  + ( L_R - M_R)
-								phase = (-1) ** phase_power
-								w = phase * w1 * w2 * w3 * w4 * w5
+    for inter in full_inter_tuples:
+        L1 , L2 , L3 , L4 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1 , L1 + 1):
+                for M2 in range(-L2 , L2 + 1 ):
+                    for M3 in range(-L3 , L3 + 1):
+                        for M4 in range(-L4 , L4 + 1):
+                            # m_1 + m_2 = M1
+                            # m_4 + m_3 = M2
+                            # m_5 + m_6 = M3
+                            # M1 + M2 = M4
+                            # M3 + M4 = M_R
+                            conds= (m_ints[0] + m_ints[1]) == M1 and\
+                            (m_ints[2] + m_ints[3]) == M2 and\
+                            (m_ints[4] + m_ints[5]) == M3 and\
+                            ( M1 + M2 ) == M4 and\
+                            ( M3 + M4 ) == M_R
+                            if conds:
+                                w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , -M1)]
+                                w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , -M2)]
+                                w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , -M3)]
+                                w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , -M4)]
+                                w5 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L_R , -M_R)]
+                                phase_power = ( L1 + L2 + L3 + L4 ) - ( M1 + M2 + M3 + M4 )  + ( L_R - M_R)
+                                phase = (-1) ** phase_power
+                                w = phase * w1 * w2 * w3 * w4 * w5
 
-								decomposed[inter][mstr] = (w)
-	return decomposed
+                                decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_7_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 , L2 , L3 , L4 , L5 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1 , L1 + 1):
-				for M2 in range(-L2 , L2 + 1 ):
-					for M3 in range(-L3 , L3 + 1):
-						for M4 in range(-L4 , L4 + 1):
-							for M5 in range(-L5 , L5 + 1):
-								# m_1 + m_2 = M1
-								# m_4 + m_3 = M2
-								# m_5 + m_6 = M3
-								# M1 + M2 = M4
-								# M3 + m_7 = M5
-								# M3 + M4 = M_R
-								conds= (m_ints[0] + m_ints[1]) == M1 and\
-								(m_ints[2] + m_ints[3]) == M2 and\
-								(m_ints[4] + m_ints[5]) == M3 and\
-								( M1 + M2 ) == M4 and\
-								( M3 + m_ints[6]) == M5 and\
-								( M4 + M5 ) == M_R
-								if conds:
-									w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , -M1)]
-									w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , -M2)]
-									w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , -M3)]
-									w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , -M4)]
-									w5 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3 , M3 , l[6] , m_ints[6] , L5 , -M5)]
-									w6 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L4 , M4 , L5 , M5 , L_R , -M_R)]
-									phase_power = ( L1 + L2 + L3 + L4 + L5 ) - ( M1 + M2 + M3 + M4 + M5 )  + ( L_R - M_R)
-									phase = (-1) ** phase_power
-									w = phase * w1 * w2 * w3 * w4 * w5 * w6
+    for inter in full_inter_tuples:
+        L1 , L2 , L3 , L4 , L5 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1 , L1 + 1):
+                for M2 in range(-L2 , L2 + 1 ):
+                    for M3 in range(-L3 , L3 + 1):
+                        for M4 in range(-L4 , L4 + 1):
+                            for M5 in range(-L5 , L5 + 1):
+                                # m_1 + m_2 = M1
+                                # m_4 + m_3 = M2
+                                # m_5 + m_6 = M3
+                                # M1 + M2 = M4
+                                # M3 + m_7 = M5
+                                # M3 + M4 = M_R
+                                conds= (m_ints[0] + m_ints[1]) == M1 and\
+                                (m_ints[2] + m_ints[3]) == M2 and\
+                                (m_ints[4] + m_ints[5]) == M3 and\
+                                ( M1 + M2 ) == M4 and\
+                                ( M3 + m_ints[6]) == M5 and\
+                                ( M4 + M5 ) == M_R
+                                if conds:
+                                    w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , -M1)]
+                                    w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , -M2)]
+                                    w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , -M3)]
+                                    w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L4 , -M4)]
+                                    w5 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3 , M3 , l[6] , m_ints[6] , L5 , -M5)]
+                                    w6 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L4 , M4 , L5 , M5 , L_R , -M_R)]
+                                    phase_power = ( L1 + L2 + L3 + L4 + L5 ) - ( M1 + M2 + M3 + M4 + M5 )  + ( L_R - M_R)
+                                    phase = (-1) ** phase_power
+                                    w = phase * w1 * w2 * w3 * w4 * w5 * w6
 
-									decomposed[inter][mstr] = (w)
-	return decomposed
+                                    decomposed[inter][mstr] = (w)
+    return decomposed
 
+@pt.rank_zero
 def rank_8_tree(l,L_R=0,M_R=0):
 
-	nodes,remainder = tree(l)
-	mstrs = get_ms(l,M_R)
-	full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
-	decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
+    nodes,remainder = tree(l)
+    mstrs = get_ms(l,M_R)
+    full_inter_tuples = tree_l_inters(l,L_R=L_R,M_R=M_R)
+    decomposed = {full_inter_tup:{mstr:0.0 for mstr in mstrs} for full_inter_tup in full_inter_tuples}
 
-	for inter in full_inter_tuples:
-		L1 , L2 , L3 , L4 , L5 , L6 = inter
-		for mstr in mstrs:
-			m_ints = [int(b) for b in mstr.split(',')]
-			for M1 in range(-L1 , L1 + 1):
-				for M2 in range(-L2 , L2 + 1 ):
-					for M3 in range(-L3 , L3 + 1):
-						for M4 in range(-L4 , L4 + 1):
-							for M5 in range(-L5 , L5 + 1):
-								for M5 in range(-L6 , L6 + 1):
-									# m_1 + m_2 = M1
-									# m_4 + m_3 = M2
-									# m_5 + m_6 = M3
-									# M1 + M2 = M5
-									# M3 + M4 = M6
-									# M5 + M6 = M_R
-									conds= (m_ints[0] + m_ints[1]) == M1 and\
-									(m_ints[2] + m_ints[3]) == M2 and\
-									(m_ints[4] + m_ints[5]) == M3 and\
-									( M1 + M2 ) == M5 and\
-									( M3 + M4) == M6 and\
-									( M5 + M6 ) == M_R
-									if conds:
-										w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , -M1)]
-										w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , -M2)]
-										w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , -M3)]
-										w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[6] , m_ints[6] , l[7] , m_ints[7] , L4 , -M4)]
-										w5 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L5 , -M5)]
-										w6 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L6 , -M6)]
-										w7 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L5 , M5 , L6 , M6 , L_R , -M_R)]
-										phase_power = ( L1 + L2 + L3 + L4 + L5 + L6 ) - ( M1 + M2 + M3 + M4 + M5 + M6 )  + ( L_R - M_R)
-										phase = (-1) ** phase_power
-										w = phase * w1 * w2 * w3 * w4 * w5 * w6 * w7
+    for inter in full_inter_tuples:
+        L1 , L2 , L3 , L4 , L5 , L6 = inter
+        for mstr in mstrs:
+            m_ints = [int(b) for b in mstr.split(',')]
+            for M1 in range(-L1 , L1 + 1):
+                for M2 in range(-L2 , L2 + 1 ):
+                    for M3 in range(-L3 , L3 + 1):
+                        for M4 in range(-L4 , L4 + 1):
+                            for M5 in range(-L5 , L5 + 1):
+                                for M5 in range(-L6 , L6 + 1):
+                                    # m_1 + m_2 = M1
+                                    # m_4 + m_3 = M2
+                                    # m_5 + m_6 = M3
+                                    # M1 + M2 = M5
+                                    # M3 + M4 = M6
+                                    # M5 + M6 = M_R
+                                    conds= (m_ints[0] + m_ints[1]) == M1 and\
+                                    (m_ints[2] + m_ints[3]) == M2 and\
+                                    (m_ints[4] + m_ints[5]) == M3 and\
+                                    ( M1 + M2 ) == M5 and\
+                                    ( M3 + M4) == M6 and\
+                                    ( M5 + M6 ) == M_R
+                                    if conds:
+                                        w1 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[0] , m_ints[0] , l[1] , m_ints[1] , L1 , -M1)]
+                                        w2 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[2] , m_ints[2] , l[3] , m_ints[3] , L2 , -M2)]
+                                        w3 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[4] , m_ints[4] , l[5] , m_ints[5] , L3 , -M3)]
+                                        w4 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(l[6] , m_ints[6] , l[7] , m_ints[7] , L4 , -M4)]
+                                        w5 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L1 , M1 , L2 , M2 , L5 , -M5)]
+                                        w6 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L3 , M3 , L4 , M4 , L6 , -M6)]
+                                        w7 = Wigner_3j['%d,%d,%d,%d,%d,%d' %(L5 , M5 , L6 , M6 , L_R , -M_R)]
+                                        phase_power = ( L1 + L2 + L3 + L4 + L5 + L6 ) - ( M1 + M2 + M3 + M4 + M5 + M6 )  + ( L_R - M_R)
+                                        phase = (-1) ** phase_power
+                                        w = phase * w1 * w2 * w3 * w4 * w5 * w6 * w7
 
-										decomposed[inter][mstr] = float(w)
-	return decomposed
+                                        decomposed[inter][mstr] = float(w)
+    return decomposed
+
+del pt


### PR DESCRIPTION
- Main change in this PR is to only evaluate (or load) the large CG and W3j libraries on the rank 0 comm. This was done in the `fitsnap3lib/lib/sym_ACE/coupling_cefficients.py` by loading in an instance of ParallelTools. Before, FitSNAP would load large pickle files from the sym_ACE library on every processor rather than just rank 0. For safety, the rank_zero decorator has been added to other functions in `fitsnap3lib/lib/sym_ACE/coupling_cefficients.py` that could lead to large pickle files in the future (the ones that generate the generalized coupling coefficient pickles in the working directory).
- Minor - updated the output for ACE potentials so that the 0th order label is not included when `bzeroflag` is set to `1`. Before this correction, outputs indicated that there was a 0th order coefficients in the `<potential>.acecoeff` files even when `bzeroflag` settings removed the 0th order coefficients. This does not affect any of the input files used in LAMMPS from FitSNAP, but may have led to confusion if users are analyzing the coefficients from their fits with the `<potential>.acecoeff` files.