### PR TITLE
Update ACE output for Numpy 2.0 compatibility with JSON serializer

### DIFF
--- a/fitsnap3lib/lib/sym_ACE/yamlpace_tools/potential.py
+++ b/fitsnap3lib/lib/sym_ACE/yamlpace_tools/potential.py
@@ -233,7 +233,7 @@ class AcePot():
             mslsts = [[int(k) for k in m.split(',')] for m in ms]
             msflat= [item for sublist in mslsts for item in sublist]
             if print_0s or betas[mu0][nu] != 0.:
-                ccoeffs =  list ( np.array(list(ccs.values())) * betas[mu0][nu] )
+                ccoeffs =  list ( np.array(list(ccs.values()), dtype=np.float64) * betas[mu0][nu] )
                 permu0[mu0].append({'mu0':mu0,
                                     'rank':rank,
                                     'ndensity':self.global_ndensity,


### PR DESCRIPTION
This fix ensures the dtype of the output for ACE coefficients is np.float64 to be compatible with the Python JSON serializer for Numpy 2.0. 
Tested with the Ta_PACE example.
Thank you to Mary Alice Cusentino for flagging this bug!
\
\
More details:
With Numpy 2.0, scalars generated with Numpy are now represented as e.g. np.float64(...) to avoid confusion with native Python scalars, see [release note](https://numpy.org/devdocs/release/2.0.0-notes.html#representation-of-numpy-scalars-changed) on this change.

In at least one FitSNAP file so far, this representation change leads to some scalar values being cast to np.float32, which the native Python JSON serializer rejects with `TypeError: Object of type float32 is not JSON serializable`. 

This is a tiny fix but creating a PR for it for documentation purposes. This may not be the first Numpy 2.0 incompatibility we come across.

