### PR TITLE
Making xyz_scraper slightly more accommodating 

### DIFF
--- a/fitsnap3lib/scrapers/xyz_scraper.py
+++ b/fitsnap3lib/scrapers/xyz_scraper.py
@@ -16,7 +16,8 @@ UNPROCESSED_KEYS = ['uid']
 PROPERTY_NAME_MAP = {'positions': 'pos',
                      'numbers': 'Z',
                      'charges': 'charge',
-                     'symbols': 'species'}
+                     'symbols': 'species',
+                     'forces': 'force'}
 
 REV_PROPERTY_NAME_MAP = dict(zip(PROPERTY_NAME_MAP.values(), PROPERTY_NAME_MAP.keys()))
 


### PR DESCRIPTION
Making the xyz_scraper recognize the 'force' label as the same as 'forces', because it took me a bit to figure out the problem and I don't want others to hit the same road-bump.

Alternative fix could be a new set of if statements in the https://github.com/FitSNAP/FitSNAP/blob/318715c62b30d974271cdee991787b7c3dc57f88/fitsnap3lib/scrapers/xyz_scraper.py#L438 block that check for singular-plural mismatch.