### PR TITLE
Quick patch

### DIFF
--- a/fitsnap3lib/calculators/lammps_snap.py
+++ b/fitsnap3lib/calculators/lammps_snap.py
@@ -88,6 +88,13 @@ class LammpsSnap(LammpsBase):
         if kw_options["dgradflag"] == 0:
             kw_options.pop("dgradflag")
         kw_options["rmin0"] = self.config.sections["BISPECTRUM"].rmin0
+        
+        # cast bools "True, False" to integer equivalents for LAMMPS compatibility
+
+        kw_options = {k:(int(v) if type(v) == bool else v) for k, v in kw_options.items()}
+
+        # collect substrings
+
         kw_substrings = [f"{k} {v}" for k, v in kw_options.items()]
         kwargs = " ".join(kw_substrings)
 

--- a/fitsnap3lib/parallel_tools.py
+++ b/fitsnap3lib/parallel_tools.py
@@ -238,7 +238,7 @@ class ParallelTools():
 
     def _set_seed(self):
         if self._rank == 0.0:
-            self._seed = randint(0, 1e5)
+            self._seed = randint(0, int(1e5))
         if self.stubs == 0:
             self._seed = self._comm.bcast(self._seed)
 


### PR DESCRIPTION
Main branch failing testing. Local tests indicate issues with data types in a few functions. No real investigation on initial PR submit, just fixes tested on Sandia machines with mpi and Python 3.12.
Changes:


- `lammps_snap.py` update: the LAMMPS SNAP compute we use can only accept integer arguments, but something in our FitSNAP pipeline now casts all bools to string bools "True, False". Added dict comprehension to change any string bools to int bools


- `parallel_tools.py` update: the `random.randint` function only accepts integer arguments, but the value `1e5` is type `float`. Did in-place cast to `int`. There was a fix to another `random` module function last year with Python version 3.11.6, this may be related?