### PR TITLE
quick fix for ACE NNs with multi_element_option=1

### DIFF
--- a/examples/Ta_PACE_PyTorch_NN/Ta.in
+++ b/examples/Ta_PACE_PyTorch_NN/Ta.in
@@ -28,6 +28,7 @@ Ta = 0.0
 layer_sizes = num_desc 64 64 1 #1000 1000 8 1
 learning_rate = 1e-5 
 num_epochs = 1
+silence_ace_multi_warning = 1
 batch_size = 4 # 363 configs in entire set
 save_state_output = Ta_Pytorch.pt
 energy_weight = 1e-2

--- a/fitsnap3lib/io/sections/solver_sections/pytorch.py
+++ b/fitsnap3lib/io/sections/solver_sections/pytorch.py
@@ -12,8 +12,7 @@ try:
             super().__init__(name, config, pt, infile, args)
             self.allowedkeys = ['layer_sizes', 'learning_rate', 'num_epochs', 'batch_size', 'save_state_output',
                                 'save_freq', 'save_state_input', 'output_file', 'energy_weight', 'force_weight',
-                                'training_fraction', 'multi_element_option', 'num_elements', 'manual_seed_flag',
-                                'shuffle_flag']
+                                'training_fraction', 'multi_element_option', 'num_elements', 'manual_seed_flag', 'silence_ace_multi_warning', 'shuffle_flag']
             self._check_section()
 
             self._check_if_used("SOLVER", "solver", "SVD")
@@ -35,6 +34,7 @@ try:
             self.training_fraction = self.get_value("PYTORCH", "training_fraction", "NaN", "float")
             self.global_fraction_bool = False
             self.multi_element_option = self.get_value("PYTORCH", "multi_element_option", "1", "int")
+            self.silence_ace_multi_warning = self.get_value("PYTORCH", "silence_ace_multi_warning", "0", "int")
             self.manual_seed_flag = self.get_value("PYTORCH", "manual_seed_flag", "False", "bool")
             self.save_state_output = self.check_path(self.get_value("PYTORCH", "save_state_output", "FitTorchModel"))
             self.save_state_input = self.check_path(self.get_value("PYTORCH", "save_state_input", None))

--- a/fitsnap3lib/lib/neural_networks/write.py
+++ b/fitsnap3lib/lib/neural_networks/write.py
@@ -178,8 +178,12 @@ class ElemwiseModels(torch.nn.Module):
         per_atom_attributes = torch.zeros(elems.size(dim=0), dtype=self.dtype)
         given_elems, elem_indices = torch.unique(elems, return_inverse=True)
         for i, elem in enumerate(given_elems):
-            self.subnets[elem].to(self.dtype)
-            per_atom_attributes[elem_indices == i] = self.subnets[elem](descriptors[elem_indices == i]).flatten()
+            try:
+                self.subnets[elem].to(self.dtype)
+                per_atom_attributes[elem_indices == i] = self.subnets[elem](descriptors[elem_indices == i]).flatten()
+            except IndexError: #NOTE this is to except cases with ACE multi_element_option = 1, mapping all elements back onto the same network. We probably want a more targeted way to handle this..
+                self.subnets[0].to(self.dtype)
+                per_atom_attributes[elem_indices == i] = self.subnets[0](descriptors[elem_indices == i]).flatten()
         return per_atom_attributes
 
 class PairNN(torch.nn.Module):

--- a/fitsnap3lib/solvers/pytorch.py
+++ b/fitsnap3lib/solvers/pytorch.py
@@ -51,9 +51,13 @@ try:
                 self.num_elements = self.config.sections["ACE"].numtypes
                 if not self.silence_ace_multi_warning:
                     assert self.multi_element_option == 2, """For ACE (explicit multi-element descriptors) it is best to give a network to each descriptor.
+
 To do this, set multi_element_option = 2 in your input.
-If multi_element_option = 1 is set, you will need to account for the fact that the MLIAP python pairstyle only has one LAMMPS type per MLIAP potential in your input.
-This can be cumbersome to set up, but if it is what you want, you can suppress this warning by setting  silence_ace_multi_warning=1 in your FitSNAP input."""
+
+If multi_element_option = 1, you will need to be extra careful to not run LAMMPS with elements NOT in your fit.
+
+If you are sure this is what you want, you can suppress this warning by setting  silence_ace_multi_warning=1 in your FitSNAP input."""
+
             else:
                 raise Exception("Unsupported calculator for PyTorch solver.")
 

--- a/fitsnap3lib/solvers/pytorch.py
+++ b/fitsnap3lib/solvers/pytorch.py
@@ -42,12 +42,18 @@ try:
 
             self.global_fraction_bool = self.config.sections['PYTORCH'].global_fraction_bool
             self.training_fraction = self.config.sections['PYTORCH'].training_fraction
+            self.silence_ace_multi_warning = self.config.sections['PYTORCH'].silence_ace_multi_warning
             self.single_flag = 0
             self.multi_element_option = self.config.sections["PYTORCH"].multi_element_option
             if (self.config.sections["CALCULATOR"].calculator == "LAMMPSSNAP"):
                 self.num_elements = self.config.sections["BISPECTRUM"].numtypes
             elif (self.config.sections["CALCULATOR"].calculator == "LAMMPSPACE"):
                 self.num_elements = self.config.sections["ACE"].numtypes
+                if not self.silence_ace_multi_warning:
+                    assert self.multi_element_option == 2, """For ACE (explicit multi-element descriptors) it is best to give a network to each descriptor.
+To do this, set multi_element_option = 2 in your input.
+If multi_element_option = 1 is set, you will need to account for the fact that the MLIAP python pairstyle only has one LAMMPS type per MLIAP potential in your input.
+This can be cumbersome to set up, but if it is what you want, you can suppress this warning by setting  silence_ace_multi_warning=1 in your FitSNAP input."""
             else:
                 raise Exception("Unsupported calculator for PyTorch solver.")
 


### PR DESCRIPTION
Currently, ACE NN fits trained with `multi_element_option=1` when single-element simulations are run in LAMMPS (e.g. bulk W run for a potential trained on W-H)  _or_ only run if the user forces all lammps types to be the same FitSNAP type (type 0) when running simulations in LAMMPS.

The quick fix handles this problem on the FitSNAP end by forcing LAMMPS types > 1 to be mapped onto the network belonging to element 0 (LAMMPS type 1). This works for correctly trained and used ACE NN models with `multi_element_option=1` because with that setting, all FitSNAP types have the same network. This will allow ACE NN models previously fit with `multi_element_option=1` to run without excessive modifications to the LAMMPS input script and without requiring the user to force all lammps types to be 1. 

The `multi_element_option=1` may not be desirable for ACE based models for other pragmatic reasons. As such, users must now specify `silence_ace_multi_warning=1` to train an ACE-based NN in order to train an ACE NN model with `multi_element_option=1`. If the `silence_ace_multi_warning` flag is not set, or is set to `0`, then FitSNAP will throw an assertion error.