### PR TITLE
Temporary: force LAMMPS pytest version to tag 'patch_12Jun2025'

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -72,7 +72,7 @@ jobs:
 
         # Procedure for installing our custom branch with compute pace:
 
-        git clone https://github.com/lammps/lammps.git
+        git clone https://github.com/lammps/lammps.git --branch patch_12Jun2025 --single-branch
         cd lammps/cmake
         mkdir build
         cd build


### PR DESCRIPTION
This PR updates the version of LAMMPS that is pulled and used by pytest to the Feature Release from June 2025 (tag = patch_12Jun2025).
Recent changes to lammps/python/lammps/pylammps.py in most recent develop branch (and upcoming stable branch) break FitSNAP linear fits.
This change will allow pytests here on GitHub to complete linear fits and ideally catch other underlying bugs.
A patch to FitSNAP itself to fix the underlying issue and ensure compatibility with the upcoming stable release of LAMMPS is planned in the near future.