### PR TITLE
Update ridge.py

### DIFF
--- a/fitsnap3lib/io/sections/solver_sections/ridge.py
+++ b/fitsnap3lib/io/sections/solver_sections/ridge.py
@@ -11,5 +11,5 @@ class Ridge(Section):
         self._check_if_used("SOLVER", "solver", "SVD")
 
         self.alpha = self.get_value("RIDGE", "alpha", "1.0E-8", "float")
-        self.local_solver = self.get_value("RIDGE", "local_solver", "1", "bool")
+        self.local_solver = self.get_value("RIDGE", "local_solver", "0", "bool")
         self.delete()


### PR DESCRIPTION
Default value of a lesser used function (local_solver for ridge regression) was set to on, and would not communicate this to users. As a result many fits were poorly conditioned because this solver also applied matrix transposes to reduce dimensionality of the fit. 