### PR TITLE
default method for local ridge solver set to SVD to avoid gramian construction

### DIFF
--- a/fitsnap3lib/io/sections/solver_sections/ridge.py
+++ b/fitsnap3lib/io/sections/solver_sections/ridge.py
@@ -5,11 +5,12 @@ class Ridge(Section):
 
     def __init__(self, name, config, pt, infile, args):
         super().__init__(name, config, pt, infile, args)
-        self.allowedkeys = ['alpha','local_solver']
+        self.allowedkeys = ['alpha','local_solver','method']
         self._check_section()
 
         self._check_if_used("SOLVER", "solver", "SVD")
 
         self.alpha = self.get_value("RIDGE", "alpha", "1.0E-8", "float")
         self.local_solver = self.get_value("RIDGE", "local_solver", "1", "bool")
+        self.method = self.get_value("RIDGE", "method", "SVD", "str")
         self.delete()

--- a/fitsnap3lib/lib/ridge_solver/regressor.py
+++ b/fitsnap3lib/lib/ridge_solver/regressor.py
@@ -2,18 +2,26 @@ import numpy as np
 
 # local ridge regressor for regularized fits without sklearn
 class Local_Ridge:
-    def __init__(self,alpha=1.e-6,fit_intercept=False):
+    def __init__(self,alpha=1.e-6,fit_intercept=False,mode='SVD'):
         self.alpha = alpha
         self.fit_intercept = fit_intercept
         self.coef_ = None
+        self.mode = mode
 
-    def fit(self,X,Y):
-        xty = np.matmul(X.T,Y)
-        xtx = np.matmul(X.T,X)
-        alphI = self.alpha * np.eye(np.shape(xtx)[0])
-        normal = (xtx + alphI)
-        betas = np.matmul(np.linalg.inv(normal),xty)
-        self.coef_ = betas
+    def fit(self,X,Y,mode='SVD'):
+        if self.mode == "normal":
+            xty = X.T @ Y
+            xtx = X.T @ X
+            alphI = self.alpha * np.eye(np.shape(xtx)[0])
+            normal = (xtx + alphI)
+            betas = np.linalg.inv(normal) @ xty
+            self.coef_ = betas
+        else:
+            U, D, V = np.linalg.svd(X,full_matrices=False)
+            d2_alph = D**2 + self.alpha
+            d2_inv = np.diag(D/d2_alph)
+            betas = V.T @ d2_inv @ U.T @ Y
+            self.coef_ = betas
 
     def predict(self,X):
         assert self.coef_ != None, "must have fit before predicting values"

--- a/fitsnap3lib/solvers/ridge.py
+++ b/fitsnap3lib/solvers/ridge.py
@@ -43,6 +43,7 @@ class RIDGE(Solver):
                 aw = aw.T @ aw
                 
             alval = self.config.sections['RIDGE'].alpha
+            method = self.config.sections['RIDGE'].method
 
             if not self.config.sections['RIDGE'].local_solver:
                 try:
@@ -50,9 +51,9 @@ class RIDGE(Solver):
                     reg = Ridge(alpha = alval, fit_intercept = False)
                 except ModuleNotFoundError:
                     self.pt.single_print('Cannot find sklearn module, using local ridge solver anyway')
-                    reg = Local_Ridge(alpha = alval, fit_intercept = False)
+                    reg = Local_Ridge(alpha = alval, fit_intercept = False, mode = method)
             elif self.config.sections['RIDGE'].local_solver:
-                reg = Local_Ridge(alpha = alval, fit_intercept = False)
+                reg = Local_Ridge(alpha = alval, fit_intercept = False, mode = method)
 
             reg.fit(aw, bw)
             # self.pt.single_print('printing fit: ', reg.coef_)


### PR DESCRIPTION
For the `Local_Ridge` solver, a more numerically stable option is added for finding linear regression coefficients (betas) with L2 regression penalties. Instead of solving for betas using the normal equations for RIDGE, it uses an SVD implementation that avoids explicitly constructing the gramian matrix (A^T A) and avoids explicitly constructing the projection of responses onto the column space of A in the normal equations (A^T Y).

This new SVD implementation is now set to be the default method for obtaining RIDGE betas. It should offer more numerical stability for poorly conditioned design matrices and (in theory) can be more efficient for large fits.

Original solutions using normal equations for Ridge may be obtained by setting `method = normal` in the RIDGE section. For example

```
[RIDGE]
local_solver = 1
alpha = 1.e-4
method = normal
```

The new default SVD implementation may be selected with 

```
[RIDGE]
local_solver = 1
alpha = 1.e-4
method = SVD
```
OR

```
[RIDGE]
local_solver = 1
alpha = 1.e-4
```

Other minor notation changes were made to the Local_Ridge solver.

These additions and changes were tested validated on the Ta_PACE_RIDGE example - `method = SVD` and `method = normal` yield the same betas within reasonable numerical precision ( 10^-8 - 10^-9). The new SVD method does not significantly affect the examples in the example folder and may help provide more consistent results from machine to machine.